### PR TITLE
Custom Property Mapping

### DIFF
--- a/JAGPropertyConverter.podspec
+++ b/JAGPropertyConverter.podspec
@@ -9,6 +9,5 @@ Pod::Spec.new do |s|
   s.description = 'With minimal configuration, JAGPropertyConverter allows easy persistence, copying, or API serialization of your Model objects.  It also allows run-time querying of an object\'s properties and their attributes.'
   s.platform = :ios
   s.source_files = 'JAGPropertyConverter'
-  s.clean_paths = "JAGPropertyConverterTests", "JAGPropertyConverter.xcodeproj", "Documentation", "AppledocSettings.plist"
   s.requires_arc = true
 end

--- a/JAGPropertyConverter.xcodeproj/project.pbxproj
+++ b/JAGPropertyConverter.xcodeproj/project.pbxproj
@@ -22,9 +22,18 @@
 		11275B8C14E9D8BD00C4707C /* JAGPropertyFinderTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 11275B8414E9D8BD00C4707C /* JAGPropertyFinderTest.m */; };
 		11275B8D14E9D8BD00C4707C /* JAGPropertyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 11275B8614E9D8BD00C4707C /* JAGPropertyTest.m */; };
 		11275B8E14E9D8BD00C4707C /* PropertyModelTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 11275B8814E9D8BD00C4707C /* PropertyModelTests.m */; };
-		11275B8F14E9D8BD00C4707C /* TestModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 11275B8A14E9D8BD00C4707C /* TestModel.m */; };
 		11E60F55160A7436000BD25F /* NumberFormatterTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 11E60F54160A7436000BD25F /* NumberFormatterTest.m */; };
 		11E60F59160B96FE000BD25F /* ExampleTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 11E60F58160B96FE000BD25F /* ExampleTest.m */; };
+		891B9BCD1B554CE000DF255E /* JAGPropertyConverter+Subclass.h in Headers */ = {isa = PBXBuildFile; fileRef = 891B9BCB1B554CE000DF255E /* JAGPropertyConverter+Subclass.h */; };
+		89C0B7971A275E84007AA954 /* NSString+JAGSnakeCaseSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C0B7951A275E84007AA954 /* NSString+JAGSnakeCaseSupport.h */; };
+		89C0B7981A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C0B7961A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m */; };
+		89C0B7991A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C0B7961A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m */; };
+		89C0B7A11A278D3D007AA954 /* SnakeCaseTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 89C0B7A01A278D3D007AA954 /* SnakeCaseTest.m */; };
+		89C0B7B21A28AF2B007AA954 /* JAGPropertyMapping.h in Headers */ = {isa = PBXBuildFile; fileRef = 89C0B7B11A28AF2B007AA954 /* JAGPropertyMapping.h */; };
+		89DED0591A7AAEDD009BF46F /* NullValuesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 89DED0581A7AAEDD009BF46F /* NullValuesTest.m */; };
+		89DED0631A7AB2C5009BF46F /* NumberTestModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 89DED0601A7AB2C5009BF46F /* NumberTestModel.m */; };
+		89DED0641A7AB2C5009BF46F /* TestModel.m in Sources */ = {isa = PBXBuildFile; fileRef = 89DED0621A7AB2C5009BF46F /* TestModel.m */; };
+		8C2232ED1AA9CBB40079D7C4 /* JAGPropertyConverterWithKeypathMappingTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8C2232EC1AA9CBB40079D7C4 /* JAGPropertyConverterWithKeypathMappingTest.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,12 +69,21 @@
 		11275B8614E9D8BD00C4707C /* JAGPropertyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JAGPropertyTest.m; sourceTree = "<group>"; };
 		11275B8714E9D8BD00C4707C /* PropertyModelTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PropertyModelTests.h; sourceTree = "<group>"; };
 		11275B8814E9D8BD00C4707C /* PropertyModelTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PropertyModelTests.m; sourceTree = "<group>"; };
-		11275B8914E9D8BD00C4707C /* TestModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestModel.h; sourceTree = "<group>"; };
-		11275B8A14E9D8BD00C4707C /* TestModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestModel.m; sourceTree = "<group>"; };
 		11E60F53160A7436000BD25F /* NumberFormatterTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NumberFormatterTest.h; sourceTree = "<group>"; };
 		11E60F54160A7436000BD25F /* NumberFormatterTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NumberFormatterTest.m; sourceTree = "<group>"; };
 		11E60F57160B96FE000BD25F /* ExampleTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExampleTest.h; sourceTree = "<group>"; };
 		11E60F58160B96FE000BD25F /* ExampleTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExampleTest.m; sourceTree = "<group>"; };
+		891B9BCB1B554CE000DF255E /* JAGPropertyConverter+Subclass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "JAGPropertyConverter+Subclass.h"; sourceTree = "<group>"; };
+		89C0B7951A275E84007AA954 /* NSString+JAGSnakeCaseSupport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+JAGSnakeCaseSupport.h"; sourceTree = "<group>"; };
+		89C0B7961A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+JAGSnakeCaseSupport.m"; sourceTree = "<group>"; };
+		89C0B7A01A278D3D007AA954 /* SnakeCaseTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SnakeCaseTest.m; sourceTree = "<group>"; };
+		89C0B7B11A28AF2B007AA954 /* JAGPropertyMapping.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JAGPropertyMapping.h; sourceTree = "<group>"; };
+		89DED0581A7AAEDD009BF46F /* NullValuesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NullValuesTest.m; sourceTree = "<group>"; };
+		89DED05F1A7AB2C5009BF46F /* NumberTestModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NumberTestModel.h; sourceTree = "<group>"; };
+		89DED0601A7AB2C5009BF46F /* NumberTestModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NumberTestModel.m; sourceTree = "<group>"; };
+		89DED0611A7AB2C5009BF46F /* TestModel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestModel.h; sourceTree = "<group>"; };
+		89DED0621A7AB2C5009BF46F /* TestModel.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestModel.m; sourceTree = "<group>"; };
+		8C2232EC1AA9CBB40079D7C4 /* JAGPropertyConverterWithKeypathMappingTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JAGPropertyConverterWithKeypathMappingTest.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,10 +143,14 @@
 			children = (
 				11275B7714E9D89500C4707C /* JAGProperty.h */,
 				11275B7814E9D89500C4707C /* JAGProperty.m */,
-				11275B7914E9D89500C4707C /* JAGPropertyFinder.h */,
-				11275B7A14E9D89500C4707C /* JAGPropertyFinder.m */,
 				11275B5314E9D56200C4707C /* JAGPropertyConverter.h */,
 				11275B5414E9D56200C4707C /* JAGPropertyConverter.m */,
+				891B9BCB1B554CE000DF255E /* JAGPropertyConverter+Subclass.h */,
+				11275B7914E9D89500C4707C /* JAGPropertyFinder.h */,
+				11275B7A14E9D89500C4707C /* JAGPropertyFinder.m */,
+				89C0B7B11A28AF2B007AA954 /* JAGPropertyMapping.h */,
+				89C0B7951A275E84007AA954 /* NSString+JAGSnakeCaseSupport.h */,
+				89C0B7961A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m */,
 				11275B5114E9D56200C4707C /* Supporting Files */,
 			);
 			path = JAGPropertyConverter;
@@ -145,21 +167,23 @@
 		11275B6414E9D56200C4707C /* JAGPropertyConverterTests */ = {
 			isa = PBXGroup;
 			children = (
+				11E60F57160B96FE000BD25F /* ExampleTest.h */,
+				11E60F58160B96FE000BD25F /* ExampleTest.m */,
 				11275B8114E9D8BD00C4707C /* JAGPropertyConverterTest.h */,
 				11275B8214E9D8BD00C4707C /* JAGPropertyConverterTest.m */,
+				8C2232EC1AA9CBB40079D7C4 /* JAGPropertyConverterWithKeypathMappingTest.m */,
 				11275B8314E9D8BD00C4707C /* JAGPropertyFinderTest.h */,
 				11275B8414E9D8BD00C4707C /* JAGPropertyFinderTest.m */,
 				11275B8514E9D8BD00C4707C /* JAGPropertyTest.h */,
 				11275B8614E9D8BD00C4707C /* JAGPropertyTest.m */,
-				11275B8714E9D8BD00C4707C /* PropertyModelTests.h */,
-				11275B8814E9D8BD00C4707C /* PropertyModelTests.m */,
-				11275B8914E9D8BD00C4707C /* TestModel.h */,
-				11275B8A14E9D8BD00C4707C /* TestModel.m */,
-				11275B6514E9D56200C4707C /* Supporting Files */,
+				89DED05E1A7AB2C5009BF46F /* Models */,
+				89DED0581A7AAEDD009BF46F /* NullValuesTest.m */,
 				11E60F53160A7436000BD25F /* NumberFormatterTest.h */,
 				11E60F54160A7436000BD25F /* NumberFormatterTest.m */,
-				11E60F57160B96FE000BD25F /* ExampleTest.h */,
-				11E60F58160B96FE000BD25F /* ExampleTest.m */,
+				11275B8714E9D8BD00C4707C /* PropertyModelTests.h */,
+				11275B8814E9D8BD00C4707C /* PropertyModelTests.m */,
+				89C0B7A01A278D3D007AA954 /* SnakeCaseTest.m */,
+				11275B6514E9D56200C4707C /* Supporting Files */,
 			);
 			path = JAGPropertyConverterTests;
 			sourceTree = "<group>";
@@ -173,6 +197,17 @@
 			name = "Supporting Files";
 			sourceTree = "<group>";
 		};
+		89DED05E1A7AB2C5009BF46F /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				89DED05F1A7AB2C5009BF46F /* NumberTestModel.h */,
+				89DED0601A7AB2C5009BF46F /* NumberTestModel.m */,
+				89DED0611A7AB2C5009BF46F /* TestModel.h */,
+				89DED0621A7AB2C5009BF46F /* TestModel.m */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -182,6 +217,9 @@
 			files = (
 				11275B7D14E9D89500C4707C /* JAGProperty.h in Headers */,
 				11275B7F14E9D89500C4707C /* JAGPropertyFinder.h in Headers */,
+				89C0B7971A275E84007AA954 /* NSString+JAGSnakeCaseSupport.h in Headers */,
+				89C0B7B21A28AF2B007AA954 /* JAGPropertyMapping.h in Headers */,
+				891B9BCD1B554CE000DF255E /* JAGPropertyConverter+Subclass.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -222,7 +260,7 @@
 			name = JAGPropertyConverterTests;
 			productName = JAGPropertyConverterTests;
 			productReference = 11275B5B14E9D56200C4707C /* JAGPropertyConverterTests.octest */;
-			productType = "com.apple.product-type.bundle";
+			productType = "com.apple.product-type.bundle.ocunit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -230,7 +268,7 @@
 		11275B4214E9D56200C4707C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0440;
+				LastUpgradeCheck = 0610;
 			};
 			buildConfigurationList = 11275B4514E9D56200C4707C /* Build configuration list for PBXProject "JAGPropertyConverter" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -283,6 +321,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				11275B5514E9D56200C4707C /* JAGPropertyConverter.m in Sources */,
+				89C0B7981A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m in Sources */,
 				11275B7E14E9D89500C4707C /* JAGProperty.m in Sources */,
 				11275B8014E9D89500C4707C /* JAGPropertyFinder.m in Sources */,
 			);
@@ -292,11 +331,16 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				89DED0631A7AB2C5009BF46F /* NumberTestModel.m in Sources */,
+				89DED0591A7AAEDD009BF46F /* NullValuesTest.m in Sources */,
+				89DED0641A7AB2C5009BF46F /* TestModel.m in Sources */,
 				11275B8B14E9D8BD00C4707C /* JAGPropertyConverterTest.m in Sources */,
+				8C2232ED1AA9CBB40079D7C4 /* JAGPropertyConverterWithKeypathMappingTest.m in Sources */,
+				89C0B7991A275E84007AA954 /* NSString+JAGSnakeCaseSupport.m in Sources */,
 				11275B8C14E9D8BD00C4707C /* JAGPropertyFinderTest.m in Sources */,
 				11275B8D14E9D8BD00C4707C /* JAGPropertyTest.m in Sources */,
 				11275B8E14E9D8BD00C4707C /* PropertyModelTests.m in Sources */,
-				11275B8F14E9D8BD00C4707C /* TestModel.m in Sources */,
+				89C0B7A11A278D3D007AA954 /* SnakeCaseTest.m in Sources */,
 				11E60F55160A7436000BD25F /* NumberFormatterTest.m in Sources */,
 				11E60F59160B96FE000BD25F /* ExampleTest.m in Sources */,
 			);
@@ -328,9 +372,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -340,10 +391,15 @@
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -352,13 +408,24 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				SDKROOT = iphoneos;

--- a/JAGPropertyConverter.xcodeproj/project.pbxproj
+++ b/JAGPropertyConverter.xcodeproj/project.pbxproj
@@ -9,7 +9,6 @@
 /* Begin PBXBuildFile section */
 		11275B4F14E9D56200C4707C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11275B4E14E9D56200C4707C /* Foundation.framework */; };
 		11275B5514E9D56200C4707C /* JAGPropertyConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 11275B5414E9D56200C4707C /* JAGPropertyConverter.m */; };
-		11275B5D14E9D56200C4707C /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11275B5C14E9D56200C4707C /* SenTestingKit.framework */; };
 		11275B5F14E9D56200C4707C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11275B5E14E9D56200C4707C /* UIKit.framework */; };
 		11275B6014E9D56200C4707C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 11275B4E14E9D56200C4707C /* Foundation.framework */; };
 		11275B6314E9D56200C4707C /* libJAGPropertyConverter.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 11275B4B14E9D56200C4707C /* libJAGPropertyConverter.a */; };
@@ -52,8 +51,7 @@
 		11275B5214E9D56200C4707C /* JAGPropertyConverter-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "JAGPropertyConverter-Prefix.pch"; sourceTree = "<group>"; };
 		11275B5314E9D56200C4707C /* JAGPropertyConverter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JAGPropertyConverter.h; sourceTree = "<group>"; };
 		11275B5414E9D56200C4707C /* JAGPropertyConverter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = JAGPropertyConverter.m; sourceTree = "<group>"; };
-		11275B5B14E9D56200C4707C /* JAGPropertyConverterTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JAGPropertyConverterTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		11275B5C14E9D56200C4707C /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
+		11275B5B14E9D56200C4707C /* JAGPropertyConverterTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JAGPropertyConverterTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		11275B5E14E9D56200C4707C /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		11275B6614E9D56200C4707C /* JAGPropertyConverterTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "JAGPropertyConverterTests-Info.plist"; sourceTree = "<group>"; };
 		11275B6814E9D56200C4707C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -99,7 +97,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				11275B5D14E9D56200C4707C /* SenTestingKit.framework in Frameworks */,
 				11275B5F14E9D56200C4707C /* UIKit.framework in Frameworks */,
 				11275B6014E9D56200C4707C /* Foundation.framework in Frameworks */,
 				11275B6314E9D56200C4707C /* libJAGPropertyConverter.a in Frameworks */,
@@ -123,7 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				11275B4B14E9D56200C4707C /* libJAGPropertyConverter.a */,
-				11275B5B14E9D56200C4707C /* JAGPropertyConverterTests.octest */,
+				11275B5B14E9D56200C4707C /* JAGPropertyConverterTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -132,7 +129,6 @@
 			isa = PBXGroup;
 			children = (
 				11275B4E14E9D56200C4707C /* Foundation.framework */,
-				11275B5C14E9D56200C4707C /* SenTestingKit.framework */,
 				11275B5E14E9D56200C4707C /* UIKit.framework */,
 			);
 			name = Frameworks;
@@ -259,8 +255,8 @@
 			);
 			name = JAGPropertyConverterTests;
 			productName = JAGPropertyConverterTests;
-			productReference = 11275B5B14E9D56200C4707C /* JAGPropertyConverterTests.octest */;
-			productType = "com.apple.product-type.bundle.ocunit-test";
+			productReference = 11275B5B14E9D56200C4707C /* JAGPropertyConverterTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -268,7 +264,8 @@
 		11275B4214E9D56200C4707C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastTestingUpgradeCheck = 0640;
+				LastUpgradeCheck = 0640;
 			};
 			buildConfigurationList = 11275B4514E9D56200C4707C /* Build configuration list for PBXProject "JAGPropertyConverter" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -384,6 +381,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -419,6 +417,7 @@
 				COPY_PHASE_STRIP = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
@@ -462,13 +461,12 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(DEVELOPER_LIBRARY_DIR)/Frameworks",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JAGPropertyConverter/JAGPropertyConverter-Prefix.pch";
 				INFOPLIST_FILE = "JAGPropertyConverterTests/JAGPropertyConverterTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Debug;
 		};
@@ -477,13 +475,12 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(DEVELOPER_LIBRARY_DIR)/Frameworks",
+					"$(inherited)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "JAGPropertyConverter/JAGPropertyConverter-Prefix.pch";
 				INFOPLIST_FILE = "JAGPropertyConverterTests/JAGPropertyConverterTests-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = octest;
 			};
 			name = Release;
 		};

--- a/JAGPropertyConverter.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/JAGPropertyConverter.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:JAGPropertyConverter.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/JAGPropertyConverter/JAGProperty.h
+++ b/JAGPropertyConverter/JAGProperty.h
@@ -223,6 +223,9 @@ JAGPropertySetterSemantics;
  */
 - (BOOL)isEligibleForGarbageCollection;
 
+/// @return YES if the property is any sort bool or BOOL
+- (BOOL) isBoolean;
+
 /// @return YES if the property is any sort of integer, float, char, or BOOL
 - (BOOL) isNumber;
 

--- a/JAGPropertyConverter/JAGProperty.m
+++ b/JAGPropertyConverter/JAGProperty.m
@@ -194,6 +194,13 @@
     return class;
 }
 
+- (BOOL) isBoolean {
+    NSString *typeEncoding = [self typeEncoding];
+    return ([typeEncoding isEqualToString: @"c"]
+            || [typeEncoding isEqualToString: @"B"]
+            );
+}
+
 - (BOOL) isNumber
 {
     NSString *typeEncoding = [self typeEncoding];

--- a/JAGPropertyConverter/JAGPropertyConverter+Subclass.h
+++ b/JAGPropertyConverter/JAGPropertyConverter+Subclass.h
@@ -1,0 +1,46 @@
+//
+//  JAGPropertyConverter+Subclass.h
+//  JAGPropertyConverter
+//
+//  Created by Yen-Chia Lin on 14.07.15.
+//
+//
+
+#import "JAGPropertyConverter.h"
+#import "JAGProperty.h"
+
+@interface JAGPropertyConverter (Subclass)
+
+/** Tries to find the correct property of given object in a specific order:
+ 
+ 1. is in ignorePropertiesFromJSON array? --> ignore
+ 2. custom property mapping
+ 3. convert camel/snake case (when enabled)
+ 4. custom property mapping (again with converted key)
+ 5. check if its keyPath?
+ 
+ @param object           object to find the property for
+ @param dictKey          property name
+ 
+ @return JAGProperty object when found, otherwise nil.
+ */
+- (JAGProperty *)findPropertyOfObject:(id)object forKey:(NSString *)dictKey;
+
+/** Tries to find the correct property of given object in a specific order:
+ 
+ 1. is in ignorePropertiesFromJSON array? --> ignore
+ 2. custom property mapping
+ 3. convert camel/snake case (when enabled)
+ 4. custom property mapping (again with converted key)
+ 5. check if its keyPath?
+ 
+ @param object           object to find the property for
+ @param dictKey          property name
+ @param isKeyPath        Output parameter. Indicates if dictKey was a keyPath
+ @param remainingKeyPath Output parameter. Returns the remaining keyPath if it was
+ 
+ @return JAGProperty object when found, otherwise nil.
+ */
+- (JAGProperty *)findPropertyOfObject:(id)object forKey:(NSString *)dictKey isKeyPath:(BOOL *)isKeyPath remainingKeyPath:(NSString **)remainingKeyPath;
+
+@end

--- a/JAGPropertyConverter/JAGPropertyConverter.m
+++ b/JAGPropertyConverter/JAGPropertyConverter.m
@@ -25,10 +25,12 @@
 // THE SOFTWARE.
 
 #import "JAGPropertyConverter.h"
+#import "JAGPropertyConverter+Subclass.h"
 #import "JAGPropertyFinder.h"
 #import "JAGProperty.h"
+#import "NSString+JAGSnakeCaseSupport.h"
 
-@interface JAGPropertyConverter () 
+@interface JAGPropertyConverter ()
 
 - (id) composeCollection: (id) collection withTargetClass: (Class) targetClass;
 
@@ -44,22 +46,13 @@
  * returned either unmodified, or if there is a 'convertable'
  * targetClass, converted to that.
  */
-- (id) composeModelFromObject: (id) object withTargetClass: (Class) targetClass;
+- (id) composeModelFromObject: (id) object withTargetClass: (Class) targetClass propertyName: (NSString *) propertyName;
 
 - (BOOL) shouldConvertClass: (Class) aClass;
 
 @end
 
 @implementation JAGPropertyConverter
-
-
-@synthesize outputType = _outputType;
-@synthesize identifyDict = _identifyDict;
-@synthesize classesToConvert = _classesToConvert;
-@synthesize convertToDate = _convertToDate;
-@synthesize convertFromDate = _convertFromDate;
-@synthesize numberFormatter = _numberFormatter;
-@synthesize shouldConvertWeakProperties = _shouldConvertWeakProperties;
 
 #pragma mark - Lifecycle
 
@@ -73,9 +66,13 @@
         self.outputType = outputType;
         self.identifyDict = nil;
         self.convertToDate = nil;
+        self.convertToData = nil;
         self.convertFromDate = nil;
+        self.convertFromData = nil;
         self.classesToConvert = [NSMutableSet set];
         self.shouldConvertWeakProperties = NO;
+        self.shouldIgnoreNullValues = YES;
+        self.enableSnakeCaseSupport = NO;
     }
     return self;
 }
@@ -96,6 +93,11 @@
 }
 
 - (id) decomposeObject: (id) object {
+    return [self recursiveDecomposeObject:object];
+}
+
+// created a private recursive method so subclasses of JAGPropertyConverter can simply override the public method (decomposeObject:) to do additional pre- and/or post-processing.
+- (id) recursiveDecomposeObject: (id) object {
     if (!object) {
         return nil;
     } else if ([object isKindOfClass: [NSNull class]]
@@ -129,6 +131,8 @@
         if ( self.outputType == kJAGFullOutput
             || self.outputType == kJAGPropertyListOutput ) {
             return object;
+        } else if (self.convertFromData) {
+            return self.convertFromData(object);
         } else {
             //Object is not safe for JSON.  Removing.
             return nil;
@@ -153,7 +157,7 @@
     } else if ([object isKindOfClass: [NSArray class]]) {
         NSMutableArray *array = [NSMutableArray array];
         for (id obj in object) {
-            id value = [self decomposeObject:obj];
+            id value = [self recursiveDecomposeObject:obj];
             if (value) {
                 [array addObject: value];
             } else {
@@ -170,7 +174,7 @@
             collection = [NSMutableSet set];
         }
         for (id obj in object) {
-            id value = [self decomposeObject:obj];
+            id value = [self recursiveDecomposeObject:obj];
             if (value) {
                 [collection addObject: value];
             } else {
@@ -185,9 +189,9 @@
                 NSLog(@"JSON dictionaries must have string keys, skipping key %@", key);
                 continue;
             }
-            id value = [self decomposeObject:[object objectForKey: key]];
+            id value = [self recursiveDecomposeObject:[object objectForKey: key]];
             if (value) {
-                [dict setObject: [self decomposeObject: value] forKey: key];
+                [dict setObject: [self recursiveDecomposeObject: value] forKey: key];
             } else {
                 NSLog(@"Unable to convert %@ to properties.", [object objectForKey: key]);
             }
@@ -208,23 +212,91 @@
 
 - (NSDictionary*) convertToDictionary: (id) model {
     if (!model) return nil;
+
+    // see if target object has defined custom mappings
+    NSDictionary *customMapping = nil;
+    if ([model respondsToSelector:@selector(customPropertyMappingConvertingToJSON)]) {
+        customMapping = [(id<JAGPropertyMapping>)model customPropertyMappingConvertingToJSON];
+    }
+    
+    // see if we have to convert enums to strings
+    NSArray *enumMapping = nil;
+    if ([model respondsToSelector:@selector(enumPropertiesToConvertToJSON)]) {
+        enumMapping = [(id<JAGPropertyMapping>)model enumPropertiesToConvertToJSON];
+    }
+    
+    // get all properties which should be ignored
+    NSArray *ignoreProperties = nil;
+    if ([model respondsToSelector:@selector(ignorePropertiesToJSON)]) {
+        ignoreProperties = [(id<JAGPropertyMapping>)model ignorePropertiesToJSON];
+    }
+
     NSMutableDictionary *values = [NSMutableDictionary dictionary];
     NSArray* properties = [JAGPropertyFinder propertiesForClass:[model class]];
     NSString* propertyName;
     for (JAGProperty *property in properties) {
-        propertyName = [property name];
+        // ignore weak properties
         if (!self.shouldConvertWeakProperties && [property isWeak]) {
             continue;
         }
+        
         SEL getter = [property getter];
         if (![model respondsToSelector:getter]) {
             //Found property without a valid getter. Skipping.
             continue;
         }
+        propertyName = [property name];
+        
         //TODO: Should use the getter for this?  Harder to handle non-objects.
         id object = [model valueForKey:propertyName];
-        [values setValue:[self decomposeObject: object] forKey:propertyName];
+
+        // custom property mapping
+        if (customMapping[propertyName]) {
+            propertyName = [customMapping[propertyName] copy]; // copy the new name, will crash otherwise
+        }
+        
+        // check if we should ignore this property
+        BOOL shouldIgnoreValue = NO;
+        for (NSString *propertyToIgnore in ignoreProperties) {
+            if ([property.name isEqualToString:propertyToIgnore]) {
+                shouldIgnoreValue = YES;
+                break;
+            }
+        }
+        
+        if (shouldIgnoreValue) {
+            continue;
+        }
+
+        // check if this property must be converted from enum
+        if (enumMapping && self.convertFromEnum && [property isNumber]) {
+            for (NSString *enumProperty in enumMapping) {
+                if ([enumProperty isEqualToString:property.name]) {
+                    object = self.convertFromEnum(property.name, object, [model class]);    // eg. converts enum (int) into string
+                    break;
+                }
+            }
+        }
+        
+        // convert to snake case?
+        if (self.enableSnakeCaseSupport) {
+            propertyName = [propertyName asUnderscoreFromCamelCase];
+        }
+        
+        // set value in dictionary
+        [values setValue:[self recursiveDecomposeObject: object] forKey:propertyName];
     }
+
+    // Add all custom keypaths defined for the model.
+    if (customMapping) {
+        for (NSString *customKey in customMapping) {
+            BOOL isKeyPath = [self _isKeyPathKey:customKey];
+            if (isKeyPath) {
+                [values setValue:[self recursiveDecomposeObject:[model valueForKeyPath:customKey]] forKey:customMapping[customKey]];
+            }
+        }
+    }
+
     return values;
 }
 
@@ -232,6 +304,10 @@
 #pragma mark - Convert From Dictionary
 
 - (id) composeCollection: (id) collection withTargetClass: (Class) targetClass {
+    return [self composeCollection: collection withTargetClass: targetClass propertyName: nil];
+}
+
+- (id) composeCollection: (id) collection withTargetClass: (Class) targetClass propertyName:(NSString *)propertyName {
     if (!targetClass) {
         targetClass = [collection class];
     }
@@ -247,7 +323,7 @@
         return nil;
     }
     for (id elt in collection) {
-        id value = [self composeModelFromObject:elt];
+        id value = [self composeModelFromObject:elt propertyName:propertyName];
         if (value) {
             [mutableCollection addObject: value];
         } else {
@@ -256,21 +332,26 @@
     }
     return mutableCollection;
 }
-- (id) composeModelFromObject: (id) object {
-    return [self composeModelFromObject:object withTargetClass: nil];
+
+- (id) composeModelFromObject:(id)object {
+    return [self composeModelFromObject:object propertyName: nil];
 }
 
-- (id) composeModelFromObject: (id) object withTargetClass: (Class) targetClass {
+- (id) composeModelFromObject: (id) object propertyName: (NSString *)properyName {
+    return [self composeModelFromObject: object withTargetClass: nil propertyName: properyName];
+}
+
+- (id) composeModelFromObject: (id) object withTargetClass: (Class) targetClass propertyName: (NSString *) propertyName {
     if (!object) {
         return nil;
     } else if ([object isKindOfClass: [NSArray class]]
                || [object isKindOfClass: [NSSet class]]) {
-        return [self composeCollection:object withTargetClass:targetClass];
+        return [self composeCollection:object withTargetClass:targetClass propertyName:propertyName];
     } else if ([object isKindOfClass: [NSDictionary class]]) {
         //Is this a PropertyModel in disguise?
         Class modelClass = nil;
         if (self.identifyDict) {
-            modelClass = self.identifyDict(object);
+            modelClass = self.identifyDict(propertyName, object);
         }
         if (modelClass) {
             id model = [[modelClass alloc] init];
@@ -284,7 +365,7 @@
         } else {
             NSMutableDictionary *dict = [NSMutableDictionary dictionary];
             for (id key in object) {
-                [dict setValue: [self composeModelFromObject: [object valueForKey: key]]
+                [dict setValue: [self composeModelFromObject: [object valueForKey: key] propertyName:key]
                         forKey: key];
             }
             return dict;
@@ -298,7 +379,12 @@
                && self.convertToDate) {
         //        NSLog(@"Found prop %@ for NSDate targetClass.  Converting.", prop);
         return self.convertToDate(object);
-    } else if ( targetClass 
+    } else if (targetClass
+               && [targetClass isSubclassOfClass:[NSData class]]
+               && self.convertToData) {
+        //        NSLog(@"Found prop %@ for NSData targetClass.  Converting.", prop);
+        return self.convertToData(object);
+    } else if ( targetClass
                && [targetClass isSubclassOfClass:[NSURL class]]
                && [object isKindOfClass:[NSString class]]
                )
@@ -309,7 +395,7 @@
                && [targetClass isSubclassOfClass:[NSNumber class]]
                && [object isKindOfClass:[NSString class]])
     {
-        return [self.numberFormatter numberFromString:object];
+        return [self _numberFromString:object];
     } else if ([object  isKindOfClass: [NSNull class]]
                || [object isKindOfClass: [NSString class]]
                || [object isKindOfClass: [NSNumber class]]
@@ -327,29 +413,180 @@
     
 }
 
-- (void) setPropertiesOf: (id) object fromDictionary: (NSDictionary*) dictionary {
-    JAGProperty *property;
-    for (NSString *key in dictionary) {
-        property = [JAGPropertyFinder propertyForName: key inClass:[object class] ];
-        if (!property || [property isReadOnly]) continue;
-        id value = [dictionary valueForKey:key];
+- (void) setPropertiesOf: (id) object fromDictionary: (NSDictionary*) dictionary {    
+    // see if target object has some enums to convert
+    NSArray *enumMapping = nil;
+    if ([object respondsToSelector:@selector(enumPropertiesToConvertFromJSON)]) {
+        enumMapping = [(id<JAGPropertyMapping>)object enumPropertiesToConvertFromJSON];
+    }
+    
+    for (NSString *dictKey in dictionary) {
+        BOOL isKeyPath = NO;
+        NSString *remainingKeyPath = nil;
+        
+        // find correct property for given key
+        JAGProperty *property = [self findPropertyOfObject:object forKey:dictKey isKeyPath:&isKeyPath remainingKeyPath:&remainingKeyPath];
+        
+        if (!property || [property isReadOnly]) {
+            continue;
+        }
+        
+        id value = [dictionary valueForKey:dictKey];
+        
+        // NSNull handling
+        if ([value isKindOfClass:[NSNull class]]) {
+            if (self.shouldIgnoreNullValues) {
+                // ignore NSNull values (leave property value as is)
+                continue;
+            } else {
+                // clear property value (set property to nil)
+                if ([property isNumber]) {
+                    [object setValue:@(0) forKey:property.name]; // for primitive data types we still need an object
+                } else {
+                    [object setValue:nil forKey:property.name];
+                }
+                continue;
+            }
+        }
+        
+        // check if the property should be converted to an enum
+        BOOL propertyValueAlreadySet = NO;
+        if (enumMapping && self.convertToEnum && [property isNumber]) {
+            for (NSString *enumProperty in enumMapping) {
+                if ([enumProperty isEqualToString:dictKey] || [[enumProperty asUnderscoreFromCamelCase] isEqualToString:dictKey]) {
+                    [object setValue:@(self.convertToEnum(dictKey, value, [object class])) forKey:property.name];
+                    propertyValueAlreadySet = YES;
+                    continue;
+                }
+            }
+        }
+        
+        if (propertyValueAlreadySet) {
+            // value is already set by the enum-mapping
+            continue;
+        }
+        
         //See if we should convert an NSString to an NSNumber
-        if (self.numberFormatter && property.isNumber && [value isKindOfClass:[NSString class]])
-        {
+        if (self.numberFormatter && [value isKindOfClass:[NSString class]]) {
             //Handle NSNumber propertyClasses in the compose function
-            value = [self.numberFormatter numberFromString:value];
+            if (property.isBoolean) {
+                value = @([dictionary[dictKey] boolValue]);
+            } else if (property.isNumber) {
+                value = [self _numberFromString:value];
+            }
         }
         if ([property isObject]) {
             Class propertyClass = [property propertyClass];
-            value = [self composeModelFromObject: value withTargetClass:propertyClass];
+            
+            NSString *propertyName = self.enableSnakeCaseSupport ? [dictKey asCamelCaseFromUnderscore] : dictKey;
+            value = [self composeModelFromObject: value withTargetClass:propertyClass propertyName:propertyName];
         }
-        if ([property canAcceptValue:value]) {
-            [object setValue:value forKey:key];
+
+        // If the key is a keypath set the value of the property by recursively going through the keypath segments
+        if (isKeyPath && remainingKeyPath != nil) {
+            id ownedObject;
+
+            if (![object valueForKey:property.name]) {
+                [object setValue:[[property.propertyClass alloc] init] forKey:property.name];
+            }
+
+            ownedObject = [object valueForKey:property.name];
+
+            // Continue recursively
+            [self setPropertiesOf:ownedObject fromDictionary:@{remainingKeyPath: value}];
+        } else if ([property canAcceptValue:value]) {
+            [object setValue:value forKey:property.name];
         } else {
-            NSLog(@"Unable to set value of class %@ into property %@ of typeEncoding %@", 
+            NSLog(@"Unable to set value of class %@ into property %@ of typeEncoding %@",
                   [value class], [property name], [property typeEncoding]);
         }
     }
+}
+
+- (NSNumber *)_numberFromString:(NSString *)value {
+    NSNumber *number = [self.numberFormatter numberFromString:value];
+    
+    // when this method is invoked, it is garanteed that target value is of primitive or NSNumber data type:
+    // but because "true" can't be converted by -[NSNumberFormatter numberFromString:] we are converting BOOL ourselfs again
+    if (!number) {
+        number = @([value boolValue]);
+    }
+    return number;
+}
+
+- (BOOL)_isKeyPathKey:(NSString *)key {
+    return [key rangeOfString:@"."].location != NSNotFound;
+}
+
+- (JAGProperty *)findPropertyOfObject:(id)object forKey:(NSString *)dictKey {
+    return [self findPropertyOfObject:object forKey:dictKey isKeyPath:nil remainingKeyPath:nil];
+}
+
+- (JAGProperty *)findPropertyOfObject:(id)object forKey:(NSString *)dictKey isKeyPath:(BOOL *)isKeyPath remainingKeyPath:(NSString **)remainingKeyPath {
+    // get all properties which should be ignored
+    if ([object respondsToSelector:@selector(ignorePropertiesFromJSON)]) {
+        NSArray *ignoreProperties = [(id<JAGPropertyMapping>)object ignorePropertiesFromJSON];
+        
+        // check if we should ignore this property
+        for (NSString *propertyToIgnore in ignoreProperties) {
+            if ([dictKey isEqualToString:propertyToIgnore]) {
+                // ignoring property
+                return nil;
+            }
+        }
+    }
+
+    // see if target object has defined custom mappings
+    NSDictionary *customMapping = nil;
+    if ([object respondsToSelector:@selector(customPropertyMappingConvertingFromJSON)]) {
+        customMapping = [(id<JAGPropertyMapping>)object customPropertyMappingConvertingFromJSON];
+    }
+    
+    JAGProperty *property = nil;
+    NSString *key = dictKey;
+    
+    // first try custom mapping
+    if (customMapping[key]) {
+        key = customMapping[key];
+    }
+    
+    property = [JAGPropertyFinder propertyForName: key inClass:[object class]];
+    
+    if (!property) {
+        // when enabled, convert to camelCase and try again fetching property
+        if (self.enableSnakeCaseSupport) {
+            key = [key asCamelCaseFromUnderscore];
+            property = [JAGPropertyFinder propertyForName: key inClass:[object class]];
+        }
+        // try custom mapping after snake case converting (again)
+        if (!property) {
+            if (customMapping[key]) {
+                key = customMapping[key];
+                
+                property = [JAGPropertyFinder propertyForName: key inClass:[object class] ];
+            }
+            
+            // Check if the key is a keypath (e.g. "someProperty.somePropertyOfSomeProperty") and get the first segment (e.g. "someProperty")
+            if (!property) {
+                *isKeyPath = [self _isKeyPathKey:key];
+                
+                if (*isKeyPath) {
+                    NSRange rangeOfFirstDot = [key rangeOfString:@"."];
+                    *remainingKeyPath = [key substringFromIndex:rangeOfFirstDot.location + 1];
+                    key = [key substringToIndex:rangeOfFirstDot.location];
+                    
+                    property = [JAGPropertyFinder propertyForName: key inClass:[object class]];
+                }
+            }
+        }
+        
+        // after many tries, still couldn't find the property
+        if (!property) {
+            return nil;
+        }
+    }
+    
+    return property;
 }
 
 @end

--- a/JAGPropertyConverter/JAGPropertyFinder.m
+++ b/JAGPropertyConverter/JAGPropertyFinder.m
@@ -39,7 +39,17 @@
     NSMutableArray* propertyArray = [NSMutableArray arrayWithCapacity:count];
     for (int i = 0; i < count ; i++)
     {
-        [propertyArray addObject: [JAGProperty propertyWithObjCProperty: list[i]]];
+        JAGProperty *property = [JAGProperty propertyWithObjCProperty: list[i]];
+        
+        // iOS 8 those 4 methods are promoted to read-only properties defined in NSObject and therefore will show up in class_copyPropertyList array --> don't add them to array
+        // Source: http://stackoverflow.com/q/24873062/1146019
+        // Source: http://www.redwindsoftware.com/blog/post/2014/08/20/NSObject-has-some-new-properties-in-iOS-8.aspx
+        if (property.isReadOnly &&
+            ([property.name isEqualToString:@"hash"] || [property.name isEqualToString:@"superclass"] || [property.name isEqualToString:@"description"] || [property.name isEqualToString:@"debugDescription"])) {
+            continue;
+        }
+        
+        [propertyArray addObject: property];
     }
     free(list);
     return propertyArray;

--- a/JAGPropertyConverter/JAGPropertyMapping.h
+++ b/JAGPropertyConverter/JAGPropertyMapping.h
@@ -1,0 +1,53 @@
+//
+//  JAGPropertyMapping.h
+//  JAGPropertyConverter
+//
+//  Created by Yen-Chia Lin on 28.11.14.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol JAGPropertyMapping <NSObject>
+
+@optional
+
+/** Mapping from JSON to Model (JSON --> Model).
+ *
+ * @return A dictionary with JSON name as key and property name as value: Dict <JSON name, property name>
+ */
+- (NSDictionary *)customPropertyMappingConvertingFromJSON;
+
+/** Mapping from Model to JSON (Model --> JSON).
+ *
+ * @return A dictionary with property name as key and JSON name as value: Dict <property name, JSON name>
+ */
+- (NSDictionary *)customPropertyMappingConvertingToJSON;
+
+/** Asks the receiver if there are any enum values which should be converted.
+ *
+ * @important The property name must always match the property name where it came from. (eg. fromJSON = the json name, toJSON = the model property name)
+ *            if the name is custom-name mapped.
+ *
+ * @return A array with NSString property names which are indicating the properties for the model which are enums and should be converted to something else.
+ *         Implement convertToEnum and convertFromEnum to handle this.
+ */
+- (NSArray *)enumPropertiesToConvertFromJSON;
+
+/** Asks the receiver if there are any enum values which should be converted.
+ *
+ * @important The property name must always match the property name where it came from. (eg. fromJSON = the json name, toJSON = the model property name)
+ *            if the name is custom-name mapped.
+ *
+ * @return A array with NSString property names which are indicating the properties for the model which are enums and should be converted to something else.
+ *         Implement convertToEnum and convertFromEnum to handle this.
+ */
+- (NSArray *)enumPropertiesToConvertToJSON;
+
+/** Asks the receiver if there are properties to ignore when converting from JSON. */
+- (NSArray *)ignorePropertiesFromJSON;
+
+/** Asks the receiver if there are properties to ignore when converting to JSON. */
+- (NSArray *)ignorePropertiesToJSON;
+
+@end

--- a/JAGPropertyConverter/NSString+JAGSnakeCaseSupport.h
+++ b/JAGPropertyConverter/NSString+JAGSnakeCaseSupport.h
@@ -1,0 +1,18 @@
+//
+//  NSString+JAGSnakeCaseSupport.h
+//  JAGPropertyConverter
+//
+//  Created by Yen-Chia Lin on 27.11.14.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+// Source: http://stackoverflow.com/questions/1918972/camelcase-to-underscores-and-back-in-objective-c
+// Source: https://github.com/peterdeweese/es_ios_utils/blob/master/es_ios_utils/universal/ESNSCategories.m
+@interface NSString (JAGSnakeCaseSupport)
+
+- (NSString *)asCamelCaseFromUnderscore;
+- (NSString *)asUnderscoreFromCamelCase;
+
+@end

--- a/JAGPropertyConverter/NSString+JAGSnakeCaseSupport.m
+++ b/JAGPropertyConverter/NSString+JAGSnakeCaseSupport.m
@@ -1,0 +1,44 @@
+//
+//  NSString+JAGSnakeCaseSupport.m
+//  JAGPropertyConverter
+//
+//  Created by Yen-Chia Lin on 27.11.14.
+//
+//
+
+#import "NSString+JAGSnakeCaseSupport.h"
+
+@implementation NSString (JAGSnakeCaseSupport)
+
+- (NSString *)asCamelCaseFromUnderscore {
+    NSMutableString *output = [NSMutableString string];
+    BOOL makeNextCharacterUpperCase = NO;
+    for (NSInteger idx = 0; idx < [self length]; idx += 1) {
+        unichar c = [self characterAtIndex:idx];
+        if (c == '_') {
+            makeNextCharacterUpperCase = YES;
+        } else if (makeNextCharacterUpperCase) {
+            [output appendString:[[NSString stringWithCharacters:&c length:1] uppercaseString]];
+            makeNextCharacterUpperCase = NO;
+        } else {
+            [output appendFormat:@"%C", c];
+        }
+    }
+    return output;
+}
+
+- (NSString *)asUnderscoreFromCamelCase {
+    NSMutableString *output = [NSMutableString string];
+    NSCharacterSet *uppercase = [NSCharacterSet uppercaseLetterCharacterSet];
+    for (NSInteger idx = 0; idx < [self length]; idx += 1) {
+        unichar c = [self characterAtIndex:idx];
+        if ([uppercase characterIsMember:c]) {
+            [output appendFormat:@"_%@", [[NSString stringWithCharacters:&c length:1] lowercaseString]];
+        } else {
+            [output appendFormat:@"%C", c];
+        }
+    }
+    return output;
+}
+
+@end

--- a/JAGPropertyConverterTests/ExampleTest.h
+++ b/JAGPropertyConverterTests/ExampleTest.h
@@ -6,7 +6,7 @@
 //
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import "JAGPropertyMapping.h"
 
@@ -48,6 +48,6 @@
  * Examples of serialization and deserialization are given in the implementation file, 
  * that can be examined with breakpoints/etc.
  */
-@interface ExampleTest : SenTestCase
+@interface ExampleTest : XCTestCase
 
 @end

--- a/JAGPropertyConverterTests/ExampleTest.h
+++ b/JAGPropertyConverterTests/ExampleTest.h
@@ -8,6 +8,8 @@
 
 #import <SenTestingKit/SenTestingKit.h>
 
+#import "JAGPropertyMapping.h"
+
 @interface Address : NSObject
 @property (copy)    NSString        *street;
 @property (copy)    NSString        *city;
@@ -18,10 +20,26 @@
 @property (copy)    NSString        *firstName;
 @property (copy)    NSString        *lastName;
 @property (assign)  int             age;
-@property (strong)  Address         *address;
+@property (strong)  Address         *addressInformation;
 @property (strong)  NSDate          *dob;
 @property (strong)  NSArray         *favorites;
 @property (strong)  NSDictionary    *information;
+@property (strong)  NSData          *encodedInformation;
+@end
+
+@interface CustomAddress : Address <JAGPropertyMapping>
+@end
+
+@interface Tenant : User <JAGPropertyMapping>
+
+@property (strong) Address *permanentAddress;
+
+@end
+
+@interface LivingAddress : CustomAddress
+
+@property (strong) Tenant *tenant;
+
 @end
 
 /**

--- a/JAGPropertyConverterTests/ExampleTest.m
+++ b/JAGPropertyConverterTests/ExampleTest.m
@@ -68,7 +68,7 @@ JAGPropertyConverter *converter;
     
     NSDictionary *targetDict = @{ @"age" : @55, @"firstName" : @"John", @"lastName" : @"Jacobs" };
     NSDictionary *userJsonDict = [converter decomposeObject:user];
-    STAssertEqualObjects(userJsonDict, targetDict, @"Converter decomposes model objects to JSON-compliant dictionaries.");
+    XCTAssertEqualObjects(userJsonDict, targetDict, @"Converter decomposes model objects to JSON-compliant dictionaries.");
 }
 
 - (void) testFromJSONDict {
@@ -76,9 +76,9 @@ JAGPropertyConverter *converter;
     User *user = [[User alloc] init];
     [converter setPropertiesOf:user fromDictionary:sourceDict];
     
-    STAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
-    STAssertEqualObjects(user.lastName, @"Jacobs", @"lastName should be Jacobs.");
-    STAssertEquals(user.age, 55, @"age should be 55");
+    XCTAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
+    XCTAssertEqualObjects(user.lastName, @"Jacobs", @"lastName should be Jacobs.");
+    XCTAssertEqual(user.age, 55, @"age should be 55");
 }
 
 - (void) testToJSONDictRecursive {
@@ -95,14 +95,14 @@ JAGPropertyConverter *converter;
     
     NSDictionary *targetDictWithoutAddress = @{ @"firstName" : @"John", @"lastName" : @"Jacobs", @"age" : @55 };
     NSDictionary *userDictWithoutAddress = [converter decomposeObject:user];
-    STAssertEqualObjects(userDictWithoutAddress, targetDictWithoutAddress, @"Without [Address class] in converter.classesToConvert, the converter ignores user.addressInformation.");
+    XCTAssertEqualObjects(userDictWithoutAddress, targetDictWithoutAddress, @"Without [Address class] in converter.classesToConvert, the converter ignores user.addressInformation.");
     
     converter.classesToConvert = [NSSet setWithObjects:[User class], [Address class], nil];
     NSDictionary *addressDict = @{ @"street":@"123 Main St", @"city":@"Springfield", @"country":@"USA" };
     NSDictionary *targetDictWithAddress = @{ @"firstName" : @"John", @"lastName" : @"Jacobs", @"age" : @55, @"addressInformation" : addressDict };
     
     NSDictionary *userDictWithAddress = [converter decomposeObject:user];
-    STAssertEqualObjects(userDictWithAddress, targetDictWithAddress, @"With [Address class] in converter.classesToConvert, the converter converts user.addressInformation.");
+    XCTAssertEqualObjects(userDictWithAddress, targetDictWithAddress, @"With [Address class] in converter.classesToConvert, the converter converts user.addressInformation.");
 }
 
 - (void) testFromJSONDictRecursive {
@@ -119,10 +119,10 @@ JAGPropertyConverter *converter;
     NSDictionary *addressDict = @{ @"street":@"123 Main St", @"city":@"Springfield", @"country":@"USA" };
     NSDictionary *sourceDict = @{ @"firstName" : @"John", @"lastName" : @"Jacobs", @"age" : @55, @"addressInformation" : addressDict };
     User *user = [converter composeModelFromObject:sourceDict];
-    STAssertTrue([user.addressInformation isKindOfClass:[Address class]], @"The identify block identifies both User and Address.");
-    STAssertEqualObjects(user.addressInformation.street, @"123 Main St", @"Converter finds nested properties.");
-    STAssertEqualObjects(user.addressInformation.city, @"Springfield", @"Converter finds nested properties.");
-    STAssertEqualObjects(user.addressInformation.country, @"USA", @"Converter finds nested properties.");
+    XCTAssertTrue([user.addressInformation isKindOfClass:[Address class]], @"The identify block identifies both User and Address.");
+    XCTAssertEqualObjects(user.addressInformation.street, @"123 Main St", @"Converter finds nested properties.");
+    XCTAssertEqualObjects(user.addressInformation.city, @"Springfield", @"Converter finds nested properties.");
+    XCTAssertEqualObjects(user.addressInformation.country, @"USA", @"Converter finds nested properties.");
     
     /* 
      * Note: If identifyDict block doesn't identify a class, you'll get a log message like:
@@ -145,7 +145,7 @@ JAGPropertyConverter *converter;
     NSDictionary *targetDict = @{ @"age" : @55, @"firstName" : @"John", @"lastName" : @"Jacobs",
     @"favorites" : favorites };
     NSDictionary *userDict = [converter decomposeObject:user];
-    STAssertEqualObjects(userDict, targetDict, @"The converter decomposes objects with arrays.");
+    XCTAssertEqualObjects(userDict, targetDict, @"The converter decomposes objects with arrays.");
 }
 
 - (void) testFromJSONDictWithArray {
@@ -160,7 +160,7 @@ JAGPropertyConverter *converter;
         return nil;
     };
     User *user = [converter composeModelFromObject:sourceDict];
-    STAssertEqualObjects(user.favorites, favorites, @"The converter composes objects with arrays.");
+    XCTAssertEqualObjects(user.favorites, favorites, @"The converter composes objects with arrays.");
 }
 
 - (void) testToJSONDictWithArrayRecursive {
@@ -182,7 +182,7 @@ JAGPropertyConverter *converter;
     NSDictionary *targetDict = @{ @"age" : @55, @"firstName" : @"John", @"lastName" : @"Jacobs",
     @"favorites" : favoritesDecomposed };
     NSDictionary *userDict = [converter decomposeObject:user];
-    STAssertEqualObjects(userDict, targetDict, @"The converter decomposes objects with arrays recursively.");
+    XCTAssertEqualObjects(userDict, targetDict, @"The converter decomposes objects with arrays recursively.");
 }
 
 - (void) testFromJSONDictWithArrayRecursive {
@@ -201,13 +201,13 @@ JAGPropertyConverter *converter;
     User *user = [converter composeModelFromObject:sourceDict];
     
     //The converter has converted jackDict into a user (jack).
-    STAssertTrue([user.favorites count] == 3, @"The converter composes objects with arrays recursively.");
-    STAssertTrue([user.favorites containsObject:@"cats"], @"Not surprisingly, that includes strings.");
-    STAssertEqualObjects([user.favorites objectAtIndex:1], fruits, @"It also includes NSArrays.");
+    XCTAssertTrue([user.favorites count] == 3, @"The converter composes objects with arrays recursively.");
+    XCTAssertTrue([user.favorites containsObject:@"cats"], @"Not surprisingly, that includes strings.");
+    XCTAssertEqualObjects([user.favorites objectAtIndex:1], fruits, @"It also includes NSArrays.");
     id jack = [user.favorites objectAtIndex:2];
-    STAssertTrue([jack isKindOfClass:[User class]], @"The converter composes models recursively too.");
-    STAssertEqualObjects([jack firstName], @"Jack", @"It gets the properties right as well.");
-    STAssertEquals([jack age], 12, @"Including numeric ones.");
+    XCTAssertTrue([jack isKindOfClass:[User class]], @"The converter composes models recursively too.");
+    XCTAssertEqualObjects([jack firstName], @"Jack", @"It gets the properties right as well.");
+    XCTAssertEqual([jack age], 12, @"Including numeric ones.");
 }
 
 - (void) testToJSONDictWithDict {
@@ -221,7 +221,7 @@ JAGPropertyConverter *converter;
     NSDictionary *targetDict = @{ @"age" : @55, @"firstName" : @"John", @"lastName" : @"Jacobs",
     @"information" : info };
     NSDictionary *userDict = [converter decomposeObject:user];
-    STAssertEqualObjects(userDict, targetDict, @"The converter decomposes objects with dictionaries.");
+    XCTAssertEqualObjects(userDict, targetDict, @"The converter decomposes objects with dictionaries.");
 }
 
 - (void) testFromJSONDictWithDict {
@@ -236,7 +236,7 @@ JAGPropertyConverter *converter;
         return nil;
     };
     User *user = [converter composeModelFromObject:sourceDict];
-    STAssertEqualObjects(user.information, info, @"The converter composes objects with dictionaries.");
+    XCTAssertEqualObjects(user.information, info, @"The converter composes objects with dictionaries.");
 }
 
 - (void) testToJSONDictWithDictRecursive {
@@ -272,7 +272,7 @@ JAGPropertyConverter *converter;
     @"information" : infoDict };
     converter.classesToConvert = [NSSet setWithObjects:[User class], [Address class], nil];
     NSDictionary *userDict = [converter decomposeObject:user];
-    STAssertEqualObjects(userDict, targetDict, @"The converter decomposes objects with dictionaries recursively.");
+    XCTAssertEqualObjects(userDict, targetDict, @"The converter decomposes objects with dictionaries recursively.");
 }
 
 - (void) testFromJSONDictWithDictRecursive {
@@ -297,17 +297,17 @@ JAGPropertyConverter *converter;
     };
     User *user = [converter composeModelFromObject:sourceDict];
     id jack = [user.information objectForKey:@"son"];
-    STAssertTrue([jack isKindOfClass:[User class]], @"The converter composes objects recursively, and sniffs out buried Models.");
-    STAssertEqualObjects([jack firstName], @"Jack", @"It finds their properties too!");
-    STAssertEquals([jack age], 12, @"Numeric properties are converted, many levels deep.");
+    XCTAssertTrue([jack isKindOfClass:[User class]], @"The converter composes objects recursively, and sniffs out buried Models.");
+    XCTAssertEqualObjects([jack firstName], @"Jack", @"It finds their properties too!");
+    XCTAssertEqual([jack age], 12, @"Numeric properties are converted, many levels deep.");
     
     NSArray *formerAddresses = [user.information objectForKey:@"formerAddresses"];
     Address *oldHome = [formerAddresses objectAtIndex:0];
-    STAssertEquals(oldHome.street, @"44 Old Lane", @"The converter finds models in arrays in dictionaries...");
-    STAssertEquals(oldHome.city, @"Smith City", @"The converter finds their properties, no problem.");
+    XCTAssertEqual(oldHome.street, @"44 Old Lane", @"The converter finds models in arrays in dictionaries...");
+    XCTAssertEqual(oldHome.city, @"Smith City", @"The converter finds their properties, no problem.");
     Address *reallyOldHome = [formerAddresses objectAtIndex:1];
-    STAssertEquals(reallyOldHome.street, @"6 Ancient Way", @"The converter finds models in arrays in dictionaries...");
-    STAssertEquals(reallyOldHome.city, @"Farmtown", @"The converter finds their properties, no problem.");
+    XCTAssertEqual(reallyOldHome.street, @"6 Ancient Way", @"The converter finds models in arrays in dictionaries...");
+    XCTAssertEqual(reallyOldHome.city, @"Farmtown", @"The converter finds their properties, no problem.");
     
 }
 
@@ -322,12 +322,12 @@ JAGPropertyConverter *converter;
     converter.outputType = kJAGJSONOutput;
     NSDictionary *jsonTargetDict = @{ @"age" : @55, @"firstName" : @"John", @"lastName" : @"Jacobs" };
     NSDictionary *jsonUserDict = [converter decomposeObject:user];
-    STAssertEqualObjects(jsonUserDict, jsonTargetDict, @"NSDate is not a valid JSON value type.");
+    XCTAssertEqualObjects(jsonUserDict, jsonTargetDict, @"NSDate is not a valid JSON value type.");
 
     converter.outputType = kJAGPropertyListOutput;
     NSDictionary *proplistTargetDict = @{ @"age" : @55, @"firstName" : @"John", @"lastName" : @"Jacobs", @"dob" : dob };
     NSDictionary *proplistUserDict = [converter decomposeObject:user];
-    STAssertEqualObjects(proplistUserDict, proplistTargetDict, @"NSDate is a valid PropertyList value type.");
+    XCTAssertEqualObjects(proplistUserDict, proplistTargetDict, @"NSDate is a valid PropertyList value type.");
 
     //TODO: Finish writing test.  Finish FullOutput type.
 //    converter.outputType = kJAGFullOutput;
@@ -344,12 +344,12 @@ JAGPropertyConverter *converter;
     NSDictionary *sourceDict = @{ @"age" : @"55", @"firstName" : @"John", @"lastName" : @"Jacobs" };
     User *user = [[User alloc] init];
     [converter setPropertiesOf:user fromDictionary:sourceDict];
-    STAssertEquals(user.age, 0, @"The converter doesn't want to set the int property age to the NSString value @\"55\".");
+    XCTAssertEqual(user.age, 0, @"The converter doesn't want to set the int property age to the NSString value @\"55\".");
     
     user = [[User alloc] init];
     converter.numberFormatter = [[NSNumberFormatter alloc] init];
     [converter setPropertiesOf:user fromDictionary:sourceDict];
-    STAssertEquals(user.age, 55, @"Setting numberFormatter lets the converter know it should convert strings to numeric types, and how it should do so.");
+    XCTAssertEqual(user.age, 55, @"Setting numberFormatter lets the converter know it should convert strings to numeric types, and how it should do so.");
     
     /*
      * Note that numberFormatter is NOT used decomposing a model into a dictionary.
@@ -375,7 +375,7 @@ JAGPropertyConverter *converter;
     };
     NSDictionary *targetDict = @{ @"age" : @55, @"firstName" : @"John", @"lastName" : @"Jacobs", @"dob" : @( [dob timeIntervalSince1970] ) };
     NSDictionary *userDict = [converter decomposeObject:user];
-    STAssertEqualObjects(userDict, targetDict, @"NSDate objects are converted with convertFromDate block for kJAGJSONOutputType.");
+    XCTAssertEqualObjects(userDict, targetDict, @"NSDate objects are converted with convertFromDate block for kJAGJSONOutputType.");
 }
 
 - (void) testConvertToDate {
@@ -395,7 +395,7 @@ JAGPropertyConverter *converter;
     };
     User *user = [[User alloc] init];
     [converter setPropertiesOf:user fromDictionary:sourceDict];
-    STAssertEqualObjects(user.dob, dob, @"Objects set to NSDate properties are converted with convertToDate block.");
+    XCTAssertEqualObjects(user.dob, dob, @"Objects set to NSDate properties are converted with convertToDate block.");
 }
 
 - (void) testConvertFromData {
@@ -417,7 +417,7 @@ JAGPropertyConverter *converter;
     NSDictionary *targetDict = @{ @"age" : @55, @"firstName" : @"John", @"lastName" : @"Jacobs", @"encodedInformation" : [eInformation base64EncodedStringWithOptions:NSDataBase64Encoding76CharacterLineLength
                                                                                                                           | NSDataBase64EncodingEndLineWithLineFeed] };
     NSDictionary *userDict = [converter decomposeObject:user];
-    STAssertEqualObjects(userDict, targetDict, @"NSData objects are converted with convertFromData block for kJAGJSONOutputType.");
+    XCTAssertEqualObjects(userDict, targetDict, @"NSData objects are converted with convertFromData block for kJAGJSONOutputType.");
 }
 
 - (void) testConvertToData {
@@ -436,7 +436,7 @@ JAGPropertyConverter *converter;
     };
     User *user = [[User alloc] init];
     [converter setPropertiesOf:user fromDictionary:sourceDict];
-    STAssertEqualObjects(user.encodedInformation, eInformation, @"Objects set to NSDate properties are converted with convertToDate block.");
+    XCTAssertEqualObjects(user.encodedInformation, eInformation, @"Objects set to NSDate properties are converted with convertToDate block.");
 }
 
 - (void) testToArrayOfObjects {
@@ -454,10 +454,10 @@ JAGPropertyConverter *converter;
     
     User *user1 = [users objectAtIndex:0];
     User *user2 = [users objectAtIndex:1];
-    STAssertEquals(user1.firstName, @"Jack", @"user1 should firstName Jack");
-    STAssertEquals(user1.lastName, @"Johnson", @"user1 should lastName Johnson");
-    STAssertEquals(user2.firstName, @"Joe", @"user2 should firstName Joe");
-    STAssertEquals(user2.lastName, @"Smith", @"user2 should lastName Smith");
+    XCTAssertEqual(user1.firstName, @"Jack", @"user1 should firstName Jack");
+    XCTAssertEqual(user1.lastName, @"Johnson", @"user1 should lastName Johnson");
+    XCTAssertEqual(user2.firstName, @"Joe", @"user2 should firstName Joe");
+    XCTAssertEqual(user2.lastName, @"Smith", @"user2 should lastName Smith");
 }
 
 #pragma mark - Identify Dict
@@ -465,7 +465,7 @@ JAGPropertyConverter *converter;
 - (void) testFromJSONDictWithIdentifyBlock {
     NSDictionary *sourceDict = @{ @"age" : @55, @"firstName" : @"John", @"lastName" : @"Jacobs" };
     id output = [converter composeModelFromObject:sourceDict];
-    STAssertTrue([output isKindOfClass:[NSDictionary class]], @"Without identify block, converter thinks sourceDict is just a dictionary.");
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]], @"Without identify block, converter thinks sourceDict is just a dictionary.");
     
     converter.identifyDict = ^Class (NSString *dictName, NSDictionary *dict) {
         if ([dict objectForKey:@"firstName"] || [dict objectForKey:@"lastName"]) {
@@ -474,14 +474,14 @@ JAGPropertyConverter *converter;
         return nil;
     };
     output = [converter composeModelFromObject:sourceDict];
-    STAssertTrue([output isKindOfClass:[User class]], @"With identifyDict block, the converter can sniff out the target class.");
-    STAssertEqualObjects([output firstName], @"John", @"firstName should be John.");
-    STAssertEqualObjects([output lastName], @"Jacobs", @"lastName should be Jacobs.");
-    STAssertEquals([output age], 55, @"age should be 55");
+    XCTAssertTrue([output isKindOfClass:[User class]], @"With identifyDict block, the converter can sniff out the target class.");
+    XCTAssertEqualObjects([output firstName], @"John", @"firstName should be John.");
+    XCTAssertEqualObjects([output lastName], @"Jacobs", @"lastName should be Jacobs.");
+    XCTAssertEqual([output age], 55, @"age should be 55");
     
     NSDictionary *notUserDict = @{ @"age":@55 };
     output = [converter composeModelFromObject:notUserDict];
-    STAssertTrue([output isKindOfClass:[NSDictionary class]], @"When the identify block returns nil, converter thinks the dictionary is just a dictionary.");
+    XCTAssertTrue([output isKindOfClass:[NSDictionary class]], @"When the identify block returns nil, converter thinks the dictionary is just a dictionary.");
     
     /*
      * Note that [JAGPropertyConverter setPropertiesOf:fromDictionary:] will set the properties
@@ -509,10 +509,10 @@ JAGPropertyConverter *converter;
     };
     
     User *user = [converter composeModelFromObject:sourceDict];
-    STAssertTrue([user.addressInformation isKindOfClass:[Address class]], @"The identify block identifies both User and Address.");
-    STAssertEqualObjects(user.addressInformation.street, @"123 Main St", @"Converter finds nested properties.");
-    STAssertEqualObjects(user.addressInformation.city, @"Springfield", @"Converter finds nested properties.");
-    STAssertEqualObjects(user.addressInformation.country, @"USA", @"Converter finds nested properties.");
+    XCTAssertTrue([user.addressInformation isKindOfClass:[Address class]], @"The identify block identifies both User and Address.");
+    XCTAssertEqualObjects(user.addressInformation.street, @"123 Main St", @"Converter finds nested properties.");
+    XCTAssertEqualObjects(user.addressInformation.city, @"Springfield", @"Converter finds nested properties.");
+    XCTAssertEqualObjects(user.addressInformation.country, @"USA", @"Converter finds nested properties.");
 }
 
 - (void)testFromJSONWithIdentifyDictNameWithSnakeCase {
@@ -535,10 +535,10 @@ JAGPropertyConverter *converter;
     };
     
     User *user = [converter composeModelFromObject:sourceDict];
-    STAssertTrue([user.addressInformation isKindOfClass:[Address class]], @"The identify block identifies both User and Address.");
-    STAssertEqualObjects(user.addressInformation.street, @"123 Main St", @"Converter finds nested properties.");
-    STAssertEqualObjects(user.addressInformation.city, @"Springfield", @"Converter finds nested properties.");
-    STAssertEqualObjects(user.addressInformation.country, @"USA", @"Converter finds nested properties.");
+    XCTAssertTrue([user.addressInformation isKindOfClass:[Address class]], @"The identify block identifies both User and Address.");
+    XCTAssertEqualObjects(user.addressInformation.street, @"123 Main St", @"Converter finds nested properties.");
+    XCTAssertEqualObjects(user.addressInformation.city, @"Springfield", @"Converter finds nested properties.");
+    XCTAssertEqualObjects(user.addressInformation.country, @"USA", @"Converter finds nested properties.");
 }
 
 - (void)testToJSONDictWithIdentifyDictNameWithSnakeCase {
@@ -557,14 +557,14 @@ JAGPropertyConverter *converter;
     
     NSDictionary *targetDictWithoutAddress = @{ @"first_name" : @"John", @"last_name" : @"Jacobs", @"age" : @55 };
     NSDictionary *userDictWithoutAddress = [converter decomposeObject:user];
-    STAssertEqualObjects(userDictWithoutAddress, targetDictWithoutAddress, @"Without [Address class] in converter.classesToConvert, the converter ignores user.addressInformation.");
+    XCTAssertEqualObjects(userDictWithoutAddress, targetDictWithoutAddress, @"Without [Address class] in converter.classesToConvert, the converter ignores user.addressInformation.");
     
     converter.classesToConvert = [NSSet setWithObjects:[User class], [Address class], nil];
     NSDictionary *addressDict = @{ @"street":@"123 Main St", @"city":@"Springfield", @"country":@"USA" };
     NSDictionary *targetDictWithAddress = @{ @"first_name" : @"John", @"last_name" : @"Jacobs", @"age" : @55, @"address_information" : addressDict };
     
     NSDictionary *userDictWithAddress = [converter decomposeObject:user];
-    STAssertEqualObjects(userDictWithAddress, targetDictWithAddress, @"With [Address class] in converter.classesToConvert, the converter converts user.addressInformation.");
+    XCTAssertEqualObjects(userDictWithAddress, targetDictWithAddress, @"With [Address class] in converter.classesToConvert, the converter converts user.addressInformation.");
 }
 
 #pragma mark - Snake Case Support
@@ -579,7 +579,7 @@ JAGPropertyConverter *converter;
     
     NSDictionary *targetDict = @{ @"age" : @55, @"first_name" : @"John", @"last_name" : @"Jacobs" };
     NSDictionary *userJsonDict = [converter decomposeObject:user];
-    STAssertEqualObjects(userJsonDict, targetDict, @"Converter decomposes model objects to JSON-compliant dictionaries.");
+    XCTAssertEqualObjects(userJsonDict, targetDict, @"Converter decomposes model objects to JSON-compliant dictionaries.");
 
 }
 
@@ -590,9 +590,9 @@ JAGPropertyConverter *converter;
     User *user = [[User alloc] init];
     [converter setPropertiesOf:user fromDictionary:sourceDict];
     
-    STAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
-    STAssertEqualObjects(user.lastName, @"Jacobs", @"lastName should be Jacobs.");
-    STAssertEquals(user.age, 55, @"age should be 55");
+    XCTAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
+    XCTAssertEqualObjects(user.lastName, @"Jacobs", @"lastName should be Jacobs.");
+    XCTAssertEqual(user.age, 55, @"age should be 55");
 }
 
 #pragma mark - Ignore NSNull values
@@ -602,7 +602,7 @@ JAGPropertyConverter *converter;
     NSData *data = [@"{\"age\":55,\"firstName\":\"John\",\"lastName\":null}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
     
-    STAssertEquals([dict[@"lastName"] class], [NSNull class], @"lastName should be converted to NSNull");
+    XCTAssertEqual([dict[@"lastName"] class], [NSNull class], @"lastName should be converted to NSNull");
     
     converter.shouldIgnoreNullValues = YES;
     
@@ -611,11 +611,11 @@ JAGPropertyConverter *converter;
     user.lastName = nil;
     [converter setPropertiesOf:user fromDictionary:dict];
     
-    STAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
-    STAssertEquals(user.age, 55, @"age should be 55");
+    XCTAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
+    XCTAssertEqual(user.age, 55, @"age should be 55");
     
-    STAssertNil(user.lastName, @"lastName should be nil but not NSNull");
-    STAssertFalse([user.lastName isKindOfClass:[NSNull class]], @"not NSNull");
+    XCTAssertNil(user.lastName, @"lastName should be nil but not NSNull");
+    XCTAssertFalse([user.lastName isKindOfClass:[NSNull class]], @"not NSNull");
 }
 
 - (void)testFromJSONDictIgnoringNSNullUntouchedProperty {
@@ -623,7 +623,7 @@ JAGPropertyConverter *converter;
     NSData *data = [@"{\"age\":55,\"firstName\":\"John\",\"lastName\":null}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
     
-    STAssertEquals([dict[@"lastName"] class], [NSNull class], @"lastName should be converted to NSNull");
+    XCTAssertEqual([dict[@"lastName"] class], [NSNull class], @"lastName should be converted to NSNull");
     
     converter.shouldIgnoreNullValues = YES;
     
@@ -632,11 +632,11 @@ JAGPropertyConverter *converter;
     user.lastName = @"Wick";
     [converter setPropertiesOf:user fromDictionary:dict];
     
-    STAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
-    STAssertEquals(user.age, 55, @"age should be 55");
+    XCTAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
+    XCTAssertEqual(user.age, 55, @"age should be 55");
     
-    STAssertNotNil(user.lastName, @"lastName should still be 'Wick'");
-    STAssertEqualObjects(user.lastName, @"Wick", @"should be untouched");
+    XCTAssertNotNil(user.lastName, @"lastName should still be 'Wick'");
+    XCTAssertEqualObjects(user.lastName, @"Wick", @"should be untouched");
 }
 
 - (void)testFromJSONDictClearPropertyUsingNSNull {
@@ -644,7 +644,7 @@ JAGPropertyConverter *converter;
     NSData *data = [@"{\"age\":55,\"firstName\":\"John\",\"lastName\":null}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
     
-    STAssertEquals([dict[@"lastName"] class], [NSNull class], @"lastName should be converted to NSNull");
+    XCTAssertEqual([dict[@"lastName"] class], [NSNull class], @"lastName should be converted to NSNull");
     
     converter.shouldIgnoreNullValues = NO; // NSNull values should clear the property
     
@@ -653,11 +653,11 @@ JAGPropertyConverter *converter;
     user.lastName = nil;
     [converter setPropertiesOf:user fromDictionary:dict];
     
-    STAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
-    STAssertEquals(user.age, 55, @"age should be 55");
+    XCTAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
+    XCTAssertEqual(user.age, 55, @"age should be 55");
     
-    STAssertNil(user.lastName, @"lastName should be nil but not NSNull");
-    STAssertFalse([user.lastName isKindOfClass:[NSNull class]], @"not NSNull");
+    XCTAssertNil(user.lastName, @"lastName should be nil but not NSNull");
+    XCTAssertFalse([user.lastName isKindOfClass:[NSNull class]], @"not NSNull");
 }
 
 - (void)testFromJSONDictClearPropertyUsingNSNull2 {
@@ -665,7 +665,7 @@ JAGPropertyConverter *converter;
     NSData *data = [@"{\"age\":55,\"firstName\":\"John\",\"lastName\":null}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
     
-    STAssertEquals([dict[@"lastName"] class], [NSNull class], @"lastName should be converted to NSNull");
+    XCTAssertEqual([dict[@"lastName"] class], [NSNull class], @"lastName should be converted to NSNull");
     
     converter.shouldIgnoreNullValues = NO; // NSNull values should clear the property
     
@@ -674,11 +674,11 @@ JAGPropertyConverter *converter;
     user.lastName = @"Wick";
     [converter setPropertiesOf:user fromDictionary:dict];
     
-    STAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
-    STAssertEquals(user.age, 55, @"age should be 55");
+    XCTAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
+    XCTAssertEqual(user.age, 55, @"age should be 55");
     
-    STAssertNil(user.lastName, @"lastName should be nil but not NSNull");
-    STAssertFalse([user.lastName isKindOfClass:[NSNull class]], @"not NSNull");
+    XCTAssertNil(user.lastName, @"lastName should be nil but not NSNull");
+    XCTAssertFalse([user.lastName isKindOfClass:[NSNull class]], @"not NSNull");
 }
 
 - (void)testFromJSONDictClearPropertyUsingNSNull3 {
@@ -686,7 +686,7 @@ JAGPropertyConverter *converter;
     NSData *data = [@"{\"age\":null,\"firstName\":\"John\",\"lastName\":\"Wick\"}" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *dict = [NSJSONSerialization JSONObjectWithData:data options:0 error:nil];
     
-    STAssertEquals([dict[@"age"] class], [NSNull class], @"age should be converted to NSNull");
+    XCTAssertEqual([dict[@"age"] class], [NSNull class], @"age should be converted to NSNull");
     
     converter.shouldIgnoreNullValues = NO; // NSNull values should clear the property
     
@@ -696,11 +696,11 @@ JAGPropertyConverter *converter;
     user.lastName = @"Wick";
     [converter setPropertiesOf:user fromDictionary:dict];
     
-    STAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
-    STAssertEquals(user.age, 0, @"age should be cleared");
+    XCTAssertEqualObjects(user.firstName, @"John", @"firstName should be John.");
+    XCTAssertEqual(user.age, 0, @"age should be cleared");
     
-    STAssertNotNil(user.lastName, @"lastName should still be 'Wick'");
-    STAssertEqualObjects(user.lastName, @"Wick", @"should be untouched");
+    XCTAssertNotNil(user.lastName, @"lastName should still be 'Wick'");
+    XCTAssertEqualObjects(user.lastName, @"Wick", @"should be untouched");
 }
 
 #pragma mark - Custom Property Name Mapping
@@ -716,7 +716,7 @@ JAGPropertyConverter *converter;
     
     NSDictionary *targetDict = @{ @"country" : @"USA", @"city" : @"Cuppertino", @"newCustomProperty" : @"Infinite Loop 1" };
     NSDictionary *userJsonDict = [converter decomposeObject:address];
-    STAssertEqualObjects(userJsonDict, targetDict, @"Converter decomposes model objects to JSON-compliant dictionaries.");
+    XCTAssertEqualObjects(userJsonDict, targetDict, @"Converter decomposes model objects to JSON-compliant dictionaries.");
     
 }
 
@@ -726,9 +726,9 @@ JAGPropertyConverter *converter;
     CustomAddress *address = [[CustomAddress alloc] init];
     [converter setPropertiesOf:address fromDictionary:sourceDict];
     
-    STAssertEqualObjects(address.street, @"Infinite Loop 1", @"firstName should be John.");
-    STAssertEqualObjects(address.city, @"Cuppertino", @"lastName should be Jacobs.");
-    STAssertEquals(address.country, @"USA", @"age should be 55");
+    XCTAssertEqualObjects(address.street, @"Infinite Loop 1", @"firstName should be John.");
+    XCTAssertEqualObjects(address.city, @"Cuppertino", @"lastName should be Jacobs.");
+    XCTAssertEqual(address.country, @"USA", @"age should be 55");
 }
 
 - (void)testТоJSONDictWithKeypathCustomName {
@@ -753,7 +753,7 @@ JAGPropertyConverter *converter;
 
     NSDictionary *targetDict = @{ @"country" : @"USA", @"city" : @"Cuppertino", @"street" : @"Infinite Loop 1", @"tenantName" : @"John", @"tenantPermanentAddressStreet": @"Nowhere Road 2" };
     NSDictionary *userJsonDict = [converter decomposeObject:address];
-    STAssertEqualObjects(userJsonDict, targetDict, @"Converter decomposes model objects to JSON-compliant dictionaries.");
+    XCTAssertEqualObjects(userJsonDict, targetDict, @"Converter decomposes model objects to JSON-compliant dictionaries.");
 }
 
 - (void)testFromJSONWIthKeypathCustomName {
@@ -763,11 +763,11 @@ JAGPropertyConverter *converter;
     LivingAddress *address = [[LivingAddress alloc] init];
     [converter setPropertiesOf:address fromDictionary:sourceDict];
 
-    STAssertEqualObjects(address.street, @"Infinite Loop 1", @"firstName should be John.");
-    STAssertEqualObjects(address.city, @"Cuppertino", @"lastName should be Jacobs.");
-    STAssertEquals(address.country, @"USA", @"age should be 55");
-    STAssertEquals(address.tenant.firstName, @"John", @"Tenant's firstName should be John.");
-    STAssertEquals(address.tenant.permanentAddress.street, @"Nowhere Road 2", @"Tenant's permanent address' street should be 'Nowhere Road 2'.");
+    XCTAssertEqualObjects(address.street, @"Infinite Loop 1", @"firstName should be John.");
+    XCTAssertEqualObjects(address.city, @"Cuppertino", @"lastName should be Jacobs.");
+    XCTAssertEqual(address.country, @"USA", @"age should be 55");
+    XCTAssertEqual(address.tenant.firstName, @"John", @"Tenant's firstName should be John.");
+    XCTAssertEqual(address.tenant.permanentAddress.street, @"Nowhere Road 2", @"Tenant's permanent address' street should be 'Nowhere Road 2'.");
 }
 
 @end

--- a/JAGPropertyConverterTests/JAGPropertyConverterTest.h
+++ b/JAGPropertyConverterTests/JAGPropertyConverterTest.h
@@ -23,8 +23,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface JAGPropertyConverterTest : SenTestCase
+@interface JAGPropertyConverterTest : XCTestCase
 
 @end

--- a/JAGPropertyConverterTests/JAGPropertyConverterTest.m
+++ b/JAGPropertyConverterTests/JAGPropertyConverterTest.m
@@ -53,15 +53,15 @@
 }
 
 - (void) assert: (TestModel*) testModel isEqualTo: (NSDictionary*) dict {
-    STAssertEqualObjects(testModel.testModelID, [dict valueForKey:@"testModelID"], 
+    XCTAssertEqualObjects(testModel.testModelID, [dict valueForKey:@"testModelID"], 
                          @"Model and Dictionary should have same testModelID");
-    STAssertEqualObjects(testModel.stringProperty, [dict valueForKey:@"stringProperty"], 
+    XCTAssertEqualObjects(testModel.stringProperty, [dict valueForKey:@"stringProperty"], 
                          @"Model and Dictionary should have same stringProperty");
-    STAssertEqualObjects(testModel.arrayProperty, [dict valueForKey:@"arrayProperty"], 
+    XCTAssertEqualObjects(testModel.arrayProperty, [dict valueForKey:@"arrayProperty"], 
                          @"Model and Dictionary should have same arrayProperty");
-    STAssertEqualObjects(testModel.dictionaryProperty, [dict valueForKey:@"dictionaryProperty"], 
+    XCTAssertEqualObjects(testModel.dictionaryProperty, [dict valueForKey:@"dictionaryProperty"], 
                          @"Model and Dictionary should have same dictionaryProperty");
-    STAssertEquals(testModel.intProperty, [[dict valueForKey:@"intProperty"] intValue], 
+    XCTAssertEqual(testModel.intProperty, [[dict valueForKey:@"intProperty"] intValue], 
                          @"Model and Dictionary should have same intProperty");    
 }
 
@@ -71,16 +71,16 @@
     NSLog(@"Converted to dictionary.");
     [self assert:model isEqualTo:dict];
 
-    STAssertNil([dict valueForKey:@"dateProperty"], @"JSON Dictionary should not have a date value.");
-    STAssertNil([dict valueForKey:@"cfProperty"], @"JSON Dictionary should not have a CF value.");
+    XCTAssertNil([dict valueForKey:@"dateProperty"], @"JSON Dictionary should not have a date value.");
+    XCTAssertNil([dict valueForKey:@"cfProperty"], @"JSON Dictionary should not have a CF value.");
 }
 
 - (void) testToDictionaryPropertyList {
     converter.outputType = kJAGPropertyListOutput;
     NSDictionary *dict = [converter convertToDictionary:model];
     [self assert:model isEqualTo:dict];
-    STAssertEqualObjects(model.dateProperty, [dict valueForKey:@"dateProperty"], @"PropertyList Dictionary should have a date value.");
-    STAssertNil([dict valueForKey:@"cfProperty"], @"PropertyList Dictionary should not have a CF value.");
+    XCTAssertEqualObjects(model.dateProperty, [dict valueForKey:@"dateProperty"], @"PropertyList Dictionary should have a date value.");
+    XCTAssertNil([dict valueForKey:@"cfProperty"], @"PropertyList Dictionary should not have a CF value.");
     
 }
 
@@ -88,9 +88,9 @@
     converter.outputType = kJAGFullOutput;
     NSDictionary *dict = [converter convertToDictionary:model];
     [self assert:model isEqualTo:dict];
-    STAssertEqualObjects(model.dateProperty, [dict valueForKey:@"dateProperty"], @"Full Dictionary should have a date value.");
+    XCTAssertEqualObjects(model.dateProperty, [dict valueForKey:@"dateProperty"], @"Full Dictionary should have a date value.");
     NSValue *cfValue = [dict valueForKey:@"cfProperty"];
-    STAssertNotNil(cfValue, @"Full Dictionary should have a CF value.");
+    XCTAssertNotNil(cfValue, @"Full Dictionary should have a CF value.");
     
     
 }
@@ -126,8 +126,8 @@
     TestModel *testModel = [TestModel testModel];
     [converter setPropertiesOf:testModel fromDictionary:dict];
     
-    STAssertNotNil(testModel.differentNameProperty, @"");
-    STAssertEqualObjects(testModel.differentNameProperty, @"new name", @"");
+    XCTAssertNotNil(testModel.differentNameProperty, @"");
+    XCTAssertEqualObjects(testModel.differentNameProperty, @"new name", @"");
 }
 
 - (void) testIdentifyModel {
@@ -146,24 +146,24 @@
     converter.outputType = kJAGJSONOutput;
     NSDictionary *dict = [converter decomposeObject:model];
     id setValue = [dict valueForKey:@"setProperty"];
-    STAssertNotNil(setValue, @"Converted setProperty should not be nil.");
-    STAssertTrue([setValue isKindOfClass:[NSArray class]], 
+    XCTAssertNotNil(setValue, @"Converted setProperty should not be nil.");
+    XCTAssertTrue([setValue isKindOfClass:[NSArray class]], 
                  @"setProperty %@ should be converted to an NSArray for JSON.", setValue);
     NSSet *setFromArray = [NSSet setWithArray:setValue];
-    STAssertEqualObjects(model.setProperty, setFromArray, @"Converted setProperty should have same objects.");
+    XCTAssertEqualObjects(model.setProperty, setFromArray, @"Converted setProperty should have same objects.");
     TestModel *returnedModel = [[TestModel alloc] initWithPropertiesFromDictionary:dict];
-    STAssertEqualObjects(model.setProperty, returnedModel.setProperty,  @"setProperty should be unchanged over serialization/deserialization.");
+    XCTAssertEqualObjects(model.setProperty, returnedModel.setProperty,  @"setProperty should be unchanged over serialization/deserialization.");
 }
 
 - (void) testURLPropertyJSON {
     converter.outputType = kJAGJSONOutput;
     NSDictionary *dict = [converter decomposeObject:model];
     id urlValue = [dict valueForKey:@"urlProperty"];
-    STAssertNotNil(urlValue, @"Converted urlProperty should not be nil.");
-    STAssertTrue([urlValue isKindOfClass:[NSString class]], 
+    XCTAssertNotNil(urlValue, @"Converted urlProperty should not be nil.");
+    XCTAssertTrue([urlValue isKindOfClass:[NSString class]], 
                  @"urlValue %@ should be converted to an NSString for JSON.", urlValue);
     NSURL *urlFromArray = [NSURL URLWithString:urlValue];
-    STAssertEqualObjects(urlFromArray, model.urlProperty, @"URL property should have same absolute string.");
+    XCTAssertEqualObjects(urlFromArray, model.urlProperty, @"URL property should have same absolute string.");
 }
 
 - (void) testURLPropertyJSONDeserialize {
@@ -171,9 +171,9 @@
     NSDictionary *dict = [converter decomposeObject:model];
     TestModel *model2 = [TestModel testModel];
     [model2 setPropertiesFromDictionary:dict];
-    STAssertNotNil(model2.urlProperty, @"urlProperty should not be nil.");
-    STAssertTrue([model2.urlProperty isKindOfClass: [NSURL class]], @"urlProperty should be an NSURL.");
-    STAssertEqualObjects(model2.urlProperty, model.urlProperty, @"urlProperties should be equal.");
+    XCTAssertNotNil(model2.urlProperty, @"urlProperty should not be nil.");
+    XCTAssertTrue([model2.urlProperty isKindOfClass: [NSURL class]], @"urlProperty should be an NSURL.");
+    XCTAssertEqualObjects(model2.urlProperty, model.urlProperty, @"urlProperties should be equal.");
 }
 
 - (void) testWeakProperty {
@@ -181,7 +181,7 @@
     model.weakProperty = strongReference;
     converter.outputType = kJAGFullOutput;
     NSDictionary *dict = [converter decomposeObject:model];
-    STAssertNil([dict valueForKey:@"weakProperty"], @"By default, converter should not convert weak properties");
+    XCTAssertNil([dict valueForKey:@"weakProperty"], @"By default, converter should not convert weak properties");
 }
 
 - (void) testWeakProperty2 {
@@ -190,7 +190,7 @@
     converter.outputType = kJAGFullOutput;
     converter.shouldConvertWeakProperties = YES;
     NSDictionary *dict = [converter decomposeObject:model];
-    STAssertNotNil([dict valueForKey:@"weakProperty"], @"By default, converter should not convert weak properties");
+    XCTAssertNotNil([dict valueForKey:@"weakProperty"], @"By default, converter should not convert weak properties");
 }
 
 - (void) testNSArrayWithNSNumberWithBoolFalse {
@@ -198,9 +198,9 @@
     NSNumber *zeroNum = [NSNumber numberWithInt:0];
     NSArray *array = [NSArray arrayWithObjects:falseNum, zeroNum, nil];
     id decomposed = [converter decomposeObject:array];
-    STAssertTrue([decomposed count] == 2, @"Array should have two elements after decomposing.");
+    XCTAssertTrue([decomposed count] == 2, @"Array should have two elements after decomposing.");
     id composed = [converter composeModelFromObject:array];
-    STAssertTrue([composed count] == 2, @"Array should have two elements after composing.");
+    XCTAssertTrue([composed count] == 2, @"Array should have two elements after composing.");
 }
 
 - (void) testNSDictWithNSNumberWithBoolFalse {
@@ -211,9 +211,9 @@
                           zeroNum, @"two",
                           nil];
     id decomposed = [converter decomposeObject:dict];
-    STAssertTrue([decomposed count] == 2, @"Dict should have two elements after decomposing.");
+    XCTAssertTrue([decomposed count] == 2, @"Dict should have two elements after decomposing.");
     id composed = [converter composeModelFromObject:dict];
-    STAssertTrue([composed count] == 2, @"Dict should have two elements after composing.");
+    XCTAssertTrue([composed count] == 2, @"Dict should have two elements after composing.");
 }
 
 #pragma mark - Null Values
@@ -225,7 +225,7 @@
     
     TestModel *testModel = [TestModel testModel];
     [converter setPropertiesOf:testModel fromDictionary:dict];
-    STAssertNil(testModel.stringProperty, @"");
+    XCTAssertNil(testModel.stringProperty, @"");
 }
 
 #pragma mark - Snake Case
@@ -238,8 +238,8 @@
     
     TestModel *testModel = [TestModel testModel];
     [converter setPropertiesOf:testModel fromDictionary:dict];
-    STAssertEquals(testModel.intProperty, 12345, @"camel case property should be set to 12345");
-    STAssertEqualObjects(testModel.stringProperty, @"same", @"normal property should also work normally");
+    XCTAssertEqual(testModel.intProperty, 12345, @"camel case property should be set to 12345");
+    XCTAssertEqualObjects(testModel.stringProperty, @"same", @"normal property should also work normally");
 }
 
 - (void)testSnakeCaseSupport2 {
@@ -249,7 +249,7 @@
     
     TestModel *testModel = [TestModel testModel];
     [converter setPropertiesOf:testModel fromDictionary:dict];
-    STAssertNil(testModel.stringProperty, @"not correct snake case --> nil");
+    XCTAssertNil(testModel.stringProperty, @"not correct snake case --> nil");
 }
 
 #pragma mark - Enums
@@ -270,7 +270,7 @@
     NSDictionary *dict = @{ @"enumProperty" : @"juhu" };
     
     TestModel *resultModel = [converter composeModelFromObject:dict];
-    STAssertEquals(resultModel.enumProperty, TestModelEnumTypeB, @"");
+    XCTAssertEqual(resultModel.enumProperty, TestModelEnumTypeB, @"");
 }
 
 - (void)testConvertPropertyFromEnum {
@@ -296,8 +296,8 @@
     NSDictionary *resultDict = [converter convertToDictionary:testModel];
     
     NSString *resultEnum = resultDict[@"enumProperty"];
-    STAssertNotNil(resultEnum, @"");
-    STAssertTrue([resultEnum isEqualToString:@"juhu"], @"");
+    XCTAssertNotNil(resultEnum, @"");
+    XCTAssertTrue([resultEnum isEqualToString:@"juhu"], @"");
 }
 
 - (void)testConvertPropertyToEnumWithCustomMapping {
@@ -316,7 +316,7 @@
     NSDictionary *dict = @{ @"enumProperty2" : @"juhu" };
     
     TestModel *resultModel = [converter composeModelFromObject:dict];
-    STAssertEquals(resultModel.customMappedProperty, TestModelEnumTypeB, @"");
+    XCTAssertEqual(resultModel.customMappedProperty, TestModelEnumTypeB, @"");
 }
 
 - (void)testConvertPropertyFromEnumWithCustomMapping {
@@ -342,8 +342,8 @@
     NSDictionary *resultDict = [converter convertToDictionary:testModel];
     
     NSString *resultEnum = resultDict[@"enumProperty2"];
-    STAssertNotNil(resultEnum, @"");
-    STAssertTrue([resultEnum isEqualToString:@"juhu"], @"");
+    XCTAssertNotNil(resultEnum, @"");
+    XCTAssertTrue([resultEnum isEqualToString:@"juhu"], @"");
 }
 
 - (void)testConvertPropertyToEnumWithSnakeCase {
@@ -363,7 +363,7 @@
     NSDictionary *dict = @{ @"snake_case_enum_property" : @"juhu" };
     
     TestModel *resultModel = [converter composeModelFromObject:dict];
-    STAssertEquals(resultModel.snakeCaseEnumProperty, TestModelEnumTypeB, @"");
+    XCTAssertEqual(resultModel.snakeCaseEnumProperty, TestModelEnumTypeB, @"");
 }
 
 - (void)testConvertPropertyFromEnumWithCustomMapping2 {
@@ -390,11 +390,11 @@
     NSDictionary *resultDict = [converter convertToDictionary:testModel];
     
     NSString *resultEnum = resultDict[@"snake_case_enum_property"];
-    STAssertNotNil(resultEnum, @"");
-    STAssertTrue([resultEnum isEqualToString:@"juhu"], @"");
+    XCTAssertNotNil(resultEnum, @"");
+    XCTAssertTrue([resultEnum isEqualToString:@"juhu"], @"");
     
     NSString *wrongKeyEnum = resultDict[@"snakeCaseEnumProperty"];
-    STAssertNil(wrongKeyEnum, @"result shouldn't contain this key!");
+    XCTAssertNil(wrongKeyEnum, @"result shouldn't contain this key!");
 }
 
 #pragma mark - Ignore
@@ -407,7 +407,7 @@
     
     NSDictionary *resultDict = [converter convertToDictionary:testModel];
     
-    STAssertNil(resultDict[@"ignoreProperty"], @"");
+    XCTAssertNil(resultDict[@"ignoreProperty"], @"");
 }
 
 - (void)testIgnorePropertiesToJSON {
@@ -416,7 +416,7 @@
     NSDictionary *dict = @{ @"ignoreProperty" : @"ignore me" };
     
     TestModel *resultModel = [converter composeModelFromObject:dict];
-    STAssertNil(resultModel.ignoreProperty, @"");
+    XCTAssertNil(resultModel.ignoreProperty, @"");
 }
 
 - (void)testIgnorePropertiesFromJSONWithCustomMapping {
@@ -427,7 +427,7 @@
     
     NSDictionary *resultDict = [converter convertToDictionary:testModel];
     
-    STAssertNil(resultDict[@"ignoreProperty2"], @"");
+    XCTAssertNil(resultDict[@"ignoreProperty2"], @"");
 }
 
 - (void)testIgnorePropertiesToJSONWithCustomMapping {
@@ -436,7 +436,7 @@
     NSDictionary *dict = @{ @"ignoreProperty2" : @"ignore me" };
     
     TestModel *resultModel = [converter composeModelFromObject:dict];
-    STAssertNil(resultModel.customMappedIgnoreProperty, @"");
+    XCTAssertNil(resultModel.customMappedIgnoreProperty, @"");
 }
 
 - (void)testIgnorePropertiesFromJSONWithSnakeCase {
@@ -448,8 +448,8 @@
     
     NSDictionary *resultDict = [converter convertToDictionary:testModel];
     
-    STAssertNil(resultDict[@"snake_case_ignore_property"], @"");
-    STAssertNil(resultDict[@"snakeCaseIgnoreProperty"], @"");
+    XCTAssertNil(resultDict[@"snake_case_ignore_property"], @"");
+    XCTAssertNil(resultDict[@"snakeCaseIgnoreProperty"], @"");
 }
 
 - (void)testIgnorePropertiesToJSONWithSnakeCase {
@@ -459,7 +459,7 @@
     NSDictionary *dict = @{ @"snake_case_ignore_property" : @"ignore me" };
     
     TestModel *resultModel = [converter composeModelFromObject:dict];
-    STAssertNil(resultModel.snakeCaseIgnoreProperty, @"");
+    XCTAssertNil(resultModel.snakeCaseIgnoreProperty, @"");
 }
 
 @end

--- a/JAGPropertyConverterTests/JAGPropertyConverterWithKeypathMappingTest.m
+++ b/JAGPropertyConverterTests/JAGPropertyConverterWithKeypathMappingTest.m
@@ -1,0 +1,147 @@
+//
+//  JAGPropertyConverterWithKeypathMappingTest.m
+//  JAGPropertyConverter
+//
+//  Created by Stanislav Stavrev on 06/03/15.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import "TestModel.h"
+#import "JAGPropertyConverter.h"
+
+@interface JAGPropertyConverterWithKeypathMappingTest : SenTestCase {
+@private
+    TestModel *model;
+    JAGPropertyConverter *converter;
+}
+
+@end
+
+@implementation JAGPropertyConverterWithKeypathMappingTest
+
+- (void) setUp {
+    model = [TestModel testModel];
+    [model populate];
+
+    converter = [[JAGPropertyConverter alloc] init];
+    converter.classesToConvert = [NSSet setWithObject:[TestModel class]];
+    converter.identifyDict = ^ Class (NSString *dictName, NSDictionary *dict)  {
+        if ([dict valueForKey:@"testModelID"]) {
+            return [TestModel class];
+        }
+        return nil;
+
+    };
+}
+
+- (void) assert: (TestModel*) testModel isEqualTo: (NSDictionary*) dict {
+    STAssertEqualObjects(testModel.testModelID, [dict valueForKey:@"testModelID"],
+                         @"Model and Dictionary should have same testModelID");
+    STAssertEqualObjects(testModel.stringProperty, [dict valueForKey:@"stringProperty"],
+                         @"Model and Dictionary should have same stringProperty");
+    STAssertEqualObjects(testModel.modelProperty.testModelID, [dict valueForKeyPath:@"modelProperty.testModelID"],
+                         @"Model and Dictionary should have same modelProperty");
+    STAssertEqualObjects(testModel.arrayProperty, [dict valueForKey:@"arrayProperty"],
+                         @"Model and Dictionary should have same arrayProperty");
+    STAssertEqualObjects(testModel.dictionaryProperty, [dict valueForKey:@"dictionaryProperty"],
+                         @"Model and Dictionary should have same dictionaryProperty");
+    STAssertEquals(testModel.intProperty, [[dict valueForKey:@"intProperty"] intValue],
+                   @"Model and Dictionary should have same intProperty");
+}
+
+- (void) testKeypathPropertiesToDictionaryJSON {
+    converter.outputType = kJAGJSONOutput;
+    NSDictionary *dict = [converter convertToDictionary:model];
+    NSLog(@"Converted to dictionary.");
+    [self assert:model isEqualTo:dict];
+
+    STAssertEquals(dict[@"keypathProperty1"], model.modelProperty.testModelID, @"JSON Dictionary should have set the keypath property properly.");
+    STAssertEquals(dict[@"keypathProperty2"], model.modelProperty.modelProperty.testModelID, @"JSON Dictionary should have set the keypath property properly.");
+}
+
+
+- (void)testToModelWithKeypathCustomMapping {
+    // custom mapping is directly implemented by TestModel with <JAGPropertyMapping>
+    NSDictionary *dict = @{@"testModelID": @"M123122",
+                           @"keypathProperty1": @"MPID001",
+                           @"keypathProperty2": @"MPID002"};
+
+    TestModel *testModel = [TestModel testModel];
+    [converter setPropertiesOf:testModel fromDictionary:dict];
+
+    STAssertEquals(testModel.modelProperty.testModelID, @"MPID001", @"Converted property not the same.");
+    STAssertEquals(testModel.modelProperty.modelProperty.testModelID, @"MPID002", @"Converted property not the same.");
+}
+
+- (void) testSetKeypathPropertyJSON {
+    NSDictionary *testModelDict = @{@"testModelID": @"G653",
+                                    @"stringProperty": @"Happy",
+                                    @"keypathProperty1": @"MPID001",
+                                    @"keypathProperty2": @"MPID002"};
+
+    TestModel *testModel = [converter composeModelFromObject:testModelDict];
+
+    STAssertEquals(testModel.modelProperty.testModelID, @"MPID001", @"Converted property not the same.");
+    STAssertEquals(testModel.modelProperty.modelProperty.testModelID, @"MPID002", @"Converted property not the same.");
+}
+
+- (void) testSetDirectKeypathPropertyJSON {
+    NSDictionary *testModelDict = @{@"testModelID": @"G653",
+                                    @"modelProperty.intProperty": @(1337),
+                                    @"modelProperty.modelProperty.intProperty": @(13377331),
+                                    @"modelProperty.modelProperty.stringProperty": @(10920)};
+
+    TestModel *testModel = [converter composeModelFromObject:testModelDict];
+
+    STAssertEquals(testModel.modelProperty.intProperty, 1337, @"Converted property not the same.");
+    STAssertEquals(testModel.modelProperty.modelProperty.intProperty, 13377331, @"Converted property not the same.");
+}
+
+- (void)testKeypathPropertyWithWrongTypeOfValue {
+    NSDictionary *testModelDict = @{@"testModelID": @(999),
+                                    @"stringProperty": @(888),
+                                    @"keypathProperty1": @(1111),
+                                    @"keypathProperty2": @(777),
+                                    @"modelProperty.arrayProperty": @(1337),
+                                    @"modelProperty.modelProperty.intProperty": @"1337",
+                                    @"modelProperty.stringProperty": [NSNull null]};
+
+    TestModel *testModel = [converter composeModelFromObject:testModelDict];
+
+    STAssertNil(testModel.modelProperty.testModelID, @"Converter is passed wrong value type. Property should be nil.");
+    STAssertNil(testModel.modelProperty.modelProperty.testModelID, @"Converter is passed wrong value type. Property should be nil.");
+    STAssertNil(testModel.modelProperty.stringProperty, @"Converter is passed wrong value type. Property should be nil.");
+    STAssertEquals(testModel.modelProperty.modelProperty.intProperty, 0, @"Converter is passed wrong value type. Property should be nil.");
+    STAssertNil(testModel.modelProperty.arrayProperty, @"Converter is passed wrong value type. Property should be nil.");
+}
+
+- (void)testKeypathPropertyWithNullValue {
+    NSDictionary *testModelDict = @{@"testModelID": @"G653",
+                                    @"modelProperty.modelProperty.setProperty": [NSNull null]};
+
+    TestModel *testModel = [converter composeModelFromObject:testModelDict];
+
+    STAssertNil(testModel.modelProperty.modelProperty.setProperty, @"setProperty should be nil.");
+}
+
+- (void) testKeypathJSON {
+    converter.outputType = kJAGJSONOutput;
+    NSDictionary *dict = [converter decomposeObject:model];
+
+    id keypathPropertyValue1 = [dict valueForKey:@"keypathProperty1"];
+    STAssertNotNil(keypathPropertyValue1, @"Converted keypathProperty1 should not be nil.");
+    STAssertTrue([keypathPropertyValue1 isKindOfClass:[NSString class]],
+                 @"keypathProperty1 %@ should be converted to an NSString for JSON.", keypathPropertyValue1);
+
+    id keypathPropertyValue2 = [dict valueForKey:@"keypathProperty2"];
+    STAssertNotNil(keypathPropertyValue2, @"Converted keypathProperty2 should not be nil.");
+    STAssertTrue([keypathPropertyValue2 isKindOfClass:[NSString class]],
+                 @"keypathProperty2 %@ should be converted to an NSString for JSON.", keypathPropertyValue2);
+
+    TestModel *returnedModel = [[TestModel alloc] initWithPropertiesFromDictionary:dict];
+    STAssertEqualObjects(model.modelProperty.testModelID, returnedModel.modelProperty.testModelID,  @"modelProperty should be unchanged over serialization/deserialization.");
+    STAssertEqualObjects(model.modelProperty.modelProperty.testModelID, returnedModel.modelProperty.modelProperty.testModelID,  @"modelProperty should be unchanged over serialization/deserialization.");
+}
+
+@end

--- a/JAGPropertyConverterTests/JAGPropertyConverterWithKeypathMappingTest.m
+++ b/JAGPropertyConverterTests/JAGPropertyConverterWithKeypathMappingTest.m
@@ -6,11 +6,11 @@
 //
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import "TestModel.h"
 #import "JAGPropertyConverter.h"
 
-@interface JAGPropertyConverterWithKeypathMappingTest : SenTestCase {
+@interface JAGPropertyConverterWithKeypathMappingTest : XCTestCase {
 @private
     TestModel *model;
     JAGPropertyConverter *converter;
@@ -36,17 +36,17 @@
 }
 
 - (void) assert: (TestModel*) testModel isEqualTo: (NSDictionary*) dict {
-    STAssertEqualObjects(testModel.testModelID, [dict valueForKey:@"testModelID"],
+    XCTAssertEqualObjects(testModel.testModelID, [dict valueForKey:@"testModelID"],
                          @"Model and Dictionary should have same testModelID");
-    STAssertEqualObjects(testModel.stringProperty, [dict valueForKey:@"stringProperty"],
+    XCTAssertEqualObjects(testModel.stringProperty, [dict valueForKey:@"stringProperty"],
                          @"Model and Dictionary should have same stringProperty");
-    STAssertEqualObjects(testModel.modelProperty.testModelID, [dict valueForKeyPath:@"modelProperty.testModelID"],
+    XCTAssertEqualObjects(testModel.modelProperty.testModelID, [dict valueForKeyPath:@"modelProperty.testModelID"],
                          @"Model and Dictionary should have same modelProperty");
-    STAssertEqualObjects(testModel.arrayProperty, [dict valueForKey:@"arrayProperty"],
+    XCTAssertEqualObjects(testModel.arrayProperty, [dict valueForKey:@"arrayProperty"],
                          @"Model and Dictionary should have same arrayProperty");
-    STAssertEqualObjects(testModel.dictionaryProperty, [dict valueForKey:@"dictionaryProperty"],
+    XCTAssertEqualObjects(testModel.dictionaryProperty, [dict valueForKey:@"dictionaryProperty"],
                          @"Model and Dictionary should have same dictionaryProperty");
-    STAssertEquals(testModel.intProperty, [[dict valueForKey:@"intProperty"] intValue],
+    XCTAssertEqual(testModel.intProperty, [[dict valueForKey:@"intProperty"] intValue],
                    @"Model and Dictionary should have same intProperty");
 }
 
@@ -56,8 +56,8 @@
     NSLog(@"Converted to dictionary.");
     [self assert:model isEqualTo:dict];
 
-    STAssertEquals(dict[@"keypathProperty1"], model.modelProperty.testModelID, @"JSON Dictionary should have set the keypath property properly.");
-    STAssertEquals(dict[@"keypathProperty2"], model.modelProperty.modelProperty.testModelID, @"JSON Dictionary should have set the keypath property properly.");
+    XCTAssertEqual(dict[@"keypathProperty1"], model.modelProperty.testModelID, @"JSON Dictionary should have set the keypath property properly.");
+    XCTAssertEqual(dict[@"keypathProperty2"], model.modelProperty.modelProperty.testModelID, @"JSON Dictionary should have set the keypath property properly.");
 }
 
 
@@ -70,8 +70,8 @@
     TestModel *testModel = [TestModel testModel];
     [converter setPropertiesOf:testModel fromDictionary:dict];
 
-    STAssertEquals(testModel.modelProperty.testModelID, @"MPID001", @"Converted property not the same.");
-    STAssertEquals(testModel.modelProperty.modelProperty.testModelID, @"MPID002", @"Converted property not the same.");
+    XCTAssertEqual(testModel.modelProperty.testModelID, @"MPID001", @"Converted property not the same.");
+    XCTAssertEqual(testModel.modelProperty.modelProperty.testModelID, @"MPID002", @"Converted property not the same.");
 }
 
 - (void) testSetKeypathPropertyJSON {
@@ -82,8 +82,8 @@
 
     TestModel *testModel = [converter composeModelFromObject:testModelDict];
 
-    STAssertEquals(testModel.modelProperty.testModelID, @"MPID001", @"Converted property not the same.");
-    STAssertEquals(testModel.modelProperty.modelProperty.testModelID, @"MPID002", @"Converted property not the same.");
+    XCTAssertEqual(testModel.modelProperty.testModelID, @"MPID001", @"Converted property not the same.");
+    XCTAssertEqual(testModel.modelProperty.modelProperty.testModelID, @"MPID002", @"Converted property not the same.");
 }
 
 - (void) testSetDirectKeypathPropertyJSON {
@@ -94,8 +94,8 @@
 
     TestModel *testModel = [converter composeModelFromObject:testModelDict];
 
-    STAssertEquals(testModel.modelProperty.intProperty, 1337, @"Converted property not the same.");
-    STAssertEquals(testModel.modelProperty.modelProperty.intProperty, 13377331, @"Converted property not the same.");
+    XCTAssertEqual(testModel.modelProperty.intProperty, 1337, @"Converted property not the same.");
+    XCTAssertEqual(testModel.modelProperty.modelProperty.intProperty, 13377331, @"Converted property not the same.");
 }
 
 - (void)testKeypathPropertyWithWrongTypeOfValue {
@@ -109,11 +109,11 @@
 
     TestModel *testModel = [converter composeModelFromObject:testModelDict];
 
-    STAssertNil(testModel.modelProperty.testModelID, @"Converter is passed wrong value type. Property should be nil.");
-    STAssertNil(testModel.modelProperty.modelProperty.testModelID, @"Converter is passed wrong value type. Property should be nil.");
-    STAssertNil(testModel.modelProperty.stringProperty, @"Converter is passed wrong value type. Property should be nil.");
-    STAssertEquals(testModel.modelProperty.modelProperty.intProperty, 0, @"Converter is passed wrong value type. Property should be nil.");
-    STAssertNil(testModel.modelProperty.arrayProperty, @"Converter is passed wrong value type. Property should be nil.");
+    XCTAssertNil(testModel.modelProperty.testModelID, @"Converter is passed wrong value type. Property should be nil.");
+    XCTAssertNil(testModel.modelProperty.modelProperty.testModelID, @"Converter is passed wrong value type. Property should be nil.");
+    XCTAssertNil(testModel.modelProperty.stringProperty, @"Converter is passed wrong value type. Property should be nil.");
+    XCTAssertEqual(testModel.modelProperty.modelProperty.intProperty, 0, @"Converter is passed wrong value type. Property should be nil.");
+    XCTAssertNil(testModel.modelProperty.arrayProperty, @"Converter is passed wrong value type. Property should be nil.");
 }
 
 - (void)testKeypathPropertyWithNullValue {
@@ -122,7 +122,7 @@
 
     TestModel *testModel = [converter composeModelFromObject:testModelDict];
 
-    STAssertNil(testModel.modelProperty.modelProperty.setProperty, @"setProperty should be nil.");
+    XCTAssertNil(testModel.modelProperty.modelProperty.setProperty, @"setProperty should be nil.");
 }
 
 - (void) testKeypathJSON {
@@ -130,18 +130,18 @@
     NSDictionary *dict = [converter decomposeObject:model];
 
     id keypathPropertyValue1 = [dict valueForKey:@"keypathProperty1"];
-    STAssertNotNil(keypathPropertyValue1, @"Converted keypathProperty1 should not be nil.");
-    STAssertTrue([keypathPropertyValue1 isKindOfClass:[NSString class]],
+    XCTAssertNotNil(keypathPropertyValue1, @"Converted keypathProperty1 should not be nil.");
+    XCTAssertTrue([keypathPropertyValue1 isKindOfClass:[NSString class]],
                  @"keypathProperty1 %@ should be converted to an NSString for JSON.", keypathPropertyValue1);
 
     id keypathPropertyValue2 = [dict valueForKey:@"keypathProperty2"];
-    STAssertNotNil(keypathPropertyValue2, @"Converted keypathProperty2 should not be nil.");
-    STAssertTrue([keypathPropertyValue2 isKindOfClass:[NSString class]],
+    XCTAssertNotNil(keypathPropertyValue2, @"Converted keypathProperty2 should not be nil.");
+    XCTAssertTrue([keypathPropertyValue2 isKindOfClass:[NSString class]],
                  @"keypathProperty2 %@ should be converted to an NSString for JSON.", keypathPropertyValue2);
 
     TestModel *returnedModel = [[TestModel alloc] initWithPropertiesFromDictionary:dict];
-    STAssertEqualObjects(model.modelProperty.testModelID, returnedModel.modelProperty.testModelID,  @"modelProperty should be unchanged over serialization/deserialization.");
-    STAssertEqualObjects(model.modelProperty.modelProperty.testModelID, returnedModel.modelProperty.modelProperty.testModelID,  @"modelProperty should be unchanged over serialization/deserialization.");
+    XCTAssertEqualObjects(model.modelProperty.testModelID, returnedModel.modelProperty.testModelID,  @"modelProperty should be unchanged over serialization/deserialization.");
+    XCTAssertEqualObjects(model.modelProperty.modelProperty.testModelID, returnedModel.modelProperty.modelProperty.testModelID,  @"modelProperty should be unchanged over serialization/deserialization.");
 }
 
 @end

--- a/JAGPropertyConverterTests/JAGPropertyFinderTest.h
+++ b/JAGPropertyConverterTests/JAGPropertyFinderTest.h
@@ -24,8 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface JAGPropertyFinderTest : SenTestCase
+@interface JAGPropertyFinderTest : XCTestCase
 
 @end

--- a/JAGPropertyConverterTests/JAGPropertyFinderTest.m
+++ b/JAGPropertyConverterTests/JAGPropertyFinderTest.m
@@ -33,18 +33,18 @@
 
 - (void) testPropertiesForSubclass {
     NSArray *properties = [JAGPropertyFinder propertiesForSubclass:[TestModelSubclass class]];
-    STAssertTrue([properties count] == 1, 
-                 @"There should be 1 property in TestModelSubclass, but there are %d", [properties count]);
+    XCTAssertTrue([properties count] == 1, 
+                 @"There should be 1 property in TestModelSubclass, but there are %tu", [properties count]);
     JAGProperty *property = [properties objectAtIndex:0];
-    STAssertEqualObjects(property.name, @"subclassStringProperty", @"Property should have right name");
+    XCTAssertEqualObjects(property.name, @"subclassStringProperty", @"Property should have right name");
     
     
 }
 
 - (void) testPropertiesForClass {
     NSArray *properties = [JAGPropertyFinder propertiesForClass:[TestModelSubclass class]];
-    STAssertTrue([properties count] > 1, 
-                 @"There should be more than 1 properties in TestModelSubclass, but there are %d", [properties count]);
+    XCTAssertTrue([properties count] > 1, 
+                 @"There should be more than 1 properties in TestModelSubclass, but there are %tu", [properties count]);
 //    JAGProperty *property = [properties objectAtIndex:0];
 //    STAssertEqualObjects(property.name, @"subclassStringProperty", @"Property should have right name");
 }
@@ -52,13 +52,13 @@
 - (void) testPropertyForNameSubclass {
     JAGProperty* subclassStringProp = [JAGPropertyFinder propertyForName:@"subclassStringProperty" 
                                                                inClass:[TestModelSubclass class]];
-    STAssertNotNil(subclassStringProp, @"SubclassStringProp should be found.");
+    XCTAssertNotNil(subclassStringProp, @"SubclassStringProp should be found.");
 }
 
 - (void) testPropertyForNameSuperclass {
     JAGProperty* stringProp = [JAGPropertyFinder propertyForName:@"stringProperty" 
                                                                inClass:[TestModelSubclass class]];
-    STAssertNotNil(stringProp, @"StringProp should be found.");
+    XCTAssertNotNil(stringProp, @"StringProp should be found.");
 }
 
 @end

--- a/JAGPropertyConverterTests/JAGPropertyTest.h
+++ b/JAGPropertyConverterTests/JAGPropertyTest.h
@@ -24,9 +24,9 @@
 // THE SOFTWARE.
 
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import <UIKit/UIKit.h>
 
-@interface JAGPropertyTest : SenTestCase
+@interface JAGPropertyTest : XCTestCase
 
 @end

--- a/JAGPropertyConverterTests/JAGPropertyTest.m
+++ b/JAGPropertyConverterTests/JAGPropertyTest.m
@@ -69,57 +69,57 @@
 #pragma mark - Broad tests
 
 - (void) testIntProperty {
-    STAssertTrue([[intProp typeEncoding] isEqualToString:@"i"], @"Type encoding should be i, is %@", [intProp typeEncoding]);
-    STAssertTrue([intProp isNumber], @"Property should be Number.");
-    STAssertFalse([intProp isObject], @"Property should not be object.");
-    STAssertEqualObjects([intProp ivarName], @"_intProperty", @"ivarName should be correct.");
-    STAssertEquals([intProp setterSemantics], JAGPropertySetterSemanticsAssign, @"Setter semantics should be assign.");
-    STAssertEqualObjects([intProp name], @"intProperty", @"Name should be correct.");
-    STAssertFalse([intProp isReadOnly], @"intProperty should not be read-only.");
-    STAssertNil([intProp propertyClass], @"intProperty should not have a propertyClass.");
+    XCTAssertTrue([[intProp typeEncoding] isEqualToString:@"i"], @"Type encoding should be i, is %@", [intProp typeEncoding]);
+    XCTAssertTrue([intProp isNumber], @"Property should be Number.");
+    XCTAssertFalse([intProp isObject], @"Property should not be object.");
+    XCTAssertEqualObjects([intProp ivarName], @"_intProperty", @"ivarName should be correct.");
+    XCTAssertEqual([intProp setterSemantics], JAGPropertySetterSemanticsAssign, @"Setter semantics should be assign.");
+    XCTAssertEqualObjects([intProp name], @"intProperty", @"Name should be correct.");
+    XCTAssertFalse([intProp isReadOnly], @"intProperty should not be read-only.");
+    XCTAssertNil([intProp propertyClass], @"intProperty should not have a propertyClass.");
 }
 
 - (void) testModelProperty {
-    STAssertTrue([modelProp isObject], @"Property should be Object.");
-    STAssertEquals([modelProp propertyClass], [TestModel class], 
+    XCTAssertTrue([modelProp isObject], @"Property should be Object.");
+    XCTAssertEqual([modelProp propertyClass], [TestModel class], 
                    @"Return object class is %@, should be %@", [modelProp propertyClass], [TestModel class]);
 
-    STAssertTrue([[modelProp typeEncoding] isEqualToString:@"@\"TestModel\""], 
+    XCTAssertTrue([[modelProp typeEncoding] isEqualToString:@"@\"TestModel\""], 
                  @"Type encoding should be @\"TestModel\", is %@", [modelProp typeEncoding]);
-    STAssertFalse([modelProp isNumber], @"Property should not be Number.");
-    STAssertEqualObjects([modelProp ivarName], @"_modelProperty", @"ivarName should be correct.");
-    STAssertEquals([modelProp setterSemantics], JAGPropertySetterSemanticsRetain, @"Setter semantics should be retain.");
-    STAssertEqualObjects([modelProp name], @"modelProperty", @"Name should be correct.");
-    STAssertFalse([modelProp isReadOnly], @"Property should not be read-only.");
-    STAssertFalse([modelProp isId], @"ModelProeprty should not be isId");
+    XCTAssertFalse([modelProp isNumber], @"Property should not be Number.");
+    XCTAssertEqualObjects([modelProp ivarName], @"_modelProperty", @"ivarName should be correct.");
+    XCTAssertEqual([modelProp setterSemantics], JAGPropertySetterSemanticsRetain, @"Setter semantics should be retain.");
+    XCTAssertEqualObjects([modelProp name], @"modelProperty", @"Name should be correct.");
+    XCTAssertFalse([modelProp isReadOnly], @"Property should not be read-only.");
+    XCTAssertFalse([modelProp isId], @"ModelProeprty should not be isId");
 }
 
 #pragma mark - Tests for propertyClass
 
 - (void) testStringProperty {
-    STAssertTrue([stringProp isObject], @"Property should be Object.");
-    STAssertEquals([stringProp propertyClass], [NSString class], 
+    XCTAssertTrue([stringProp isObject], @"Property should be Object.");
+    XCTAssertEqual([stringProp propertyClass], [NSString class], 
                    @"Return object class is %@, should be %@", [stringProp propertyClass], [NSString class]);
     
 }
 
 - (void) testArrayProperty {
-    STAssertTrue([arrayProp isObject], @"Property should be Object.");
-    STAssertEquals([arrayProp propertyClass], [NSArray class], 
+    XCTAssertTrue([arrayProp isObject], @"Property should be Object.");
+    XCTAssertEqual([arrayProp propertyClass], [NSArray class], 
                    @"Return object class is %@, should be %@", [arrayProp propertyClass], [NSArray class]);
     
 }
 
 - (void) testSetProperty {
-    STAssertTrue([setProp isObject], @"Property should be Object.");
-    STAssertEquals([setProp propertyClass], [NSSet class], 
+    XCTAssertTrue([setProp isObject], @"Property should be Object.");
+    XCTAssertEqual([setProp propertyClass], [NSSet class], 
                    @"Return object class is %@, should be %@", [setProp propertyClass], [NSSet class]);
     
 }
 
 - (void) testDictionaryProperty {
-    STAssertTrue([dictProp isObject], @"Property should be Object.");
-    STAssertEquals([dictProp propertyClass], [NSDictionary class], 
+    XCTAssertTrue([dictProp isObject], @"Property should be Object.");
+    XCTAssertEqual([dictProp propertyClass], [NSDictionary class], 
                    @"Return object class is %@, should be %@", [dictProp propertyClass], [NSDictionary class]);
     
 }
@@ -128,36 +128,36 @@
 
 - (void) testGetter {
     SEL getter = [stringProp getter];
-    STAssertEqualObjects(NSStringFromSelector(getter), @"stringProperty", 
+    XCTAssertEqualObjects(NSStringFromSelector(getter), @"stringProperty", 
                          @"Property should have stringProperty getter, but has %@",
                          NSStringFromSelector(getter));
 }
 
 - (void) testSetter {
     SEL setter = [stringProp setter];
-    STAssertEqualObjects(NSStringFromSelector(setter), @"setStringProperty:", 
+    XCTAssertEqualObjects(NSStringFromSelector(setter), @"setStringProperty:", 
                          @"Property should have setStringProperty: setter, but has %@",
                          NSStringFromSelector(setter));
 }
 
 - (void) testCustomGetter {
     SEL customGetter = [activeProp customGetter];
-    STAssertEqualObjects(NSStringFromSelector(customGetter), @"isActive", 
+    XCTAssertEqualObjects(NSStringFromSelector(customGetter), @"isActive", 
                          @"Property should have isActive custom getter, but has %@",
                          NSStringFromSelector(customGetter));
     SEL getter = [activeProp getter];
-    STAssertEqualObjects(NSStringFromSelector(getter), @"isActive", 
+    XCTAssertEqualObjects(NSStringFromSelector(getter), @"isActive", 
                          @"Property should have isActive getter, but has %@",
                          NSStringFromSelector(getter));
 }
 
 - (void) testCustomSetter {
     SEL customSetter = [activeProp customSetter];
-    STAssertEqualObjects(NSStringFromSelector(customSetter), @"makeActive:",
+    XCTAssertEqualObjects(NSStringFromSelector(customSetter), @"makeActive:",
                          @"Property should have makeActive: custom setter, but has %@",
                          NSStringFromSelector(customSetter));
     SEL setter = [activeProp setter];
-    STAssertEqualObjects(NSStringFromSelector(setter), @"makeActive:", 
+    XCTAssertEqualObjects(NSStringFromSelector(setter), @"makeActive:", 
                          @"Property should have makeActive: setter, but has %@",
                          NSStringFromSelector(setter));
 }
@@ -165,74 +165,74 @@
 #pragma mark - YES/NO methods
 
 - (void) testIsCollection {
-    STAssertFalse([stringProp isCollection], @"String property should not be a collection.");
-    STAssertFalse([intProp isCollection], @"Int property should not be a collection.");
-    STAssertTrue([setProp isCollection], @"Set property should be a collection.");
-    STAssertTrue([arrayProp isCollection], @"Array property should be a collection.");
-    STAssertFalse([dictProp isCollection], @"Dict property should not be a collection.");
-    STAssertFalse([modelProp isCollection], @"Model property should not be a collection.");
+    XCTAssertFalse([stringProp isCollection], @"String property should not be a collection.");
+    XCTAssertFalse([intProp isCollection], @"Int property should not be a collection.");
+    XCTAssertTrue([setProp isCollection], @"Set property should be a collection.");
+    XCTAssertTrue([arrayProp isCollection], @"Array property should be a collection.");
+    XCTAssertFalse([dictProp isCollection], @"Dict property should not be a collection.");
+    XCTAssertFalse([modelProp isCollection], @"Model property should not be a collection.");
 }
 
 - (void) testWeakProperty {
     NSLog(@"weakProperty attributeEncodings: %@", [weakProperty attributeEncodings]);
-    STAssertTrue([weakProperty isWeak], @"Weak property should have isWeake true.");
+    XCTAssertTrue([weakProperty isWeak], @"Weak property should have isWeake true.");
 }
 
 - (void) testBlockProperty {
     NSLog(@"blockProperty attributeEncodings: %@", [blockProperty attributeEncodings]);
-    STAssertEqualObjects([blockProperty typeEncoding], @"@?", @"Block property should have type encoding @?");
-    STAssertTrue([blockProperty isBlock], @"Block property should have isBlock == true");   
-    STAssertNil([blockProperty propertyClass], @"Block properties should return nill properties.");
+    XCTAssertEqualObjects([blockProperty typeEncoding], @"@?", @"Block property should have type encoding @?");
+    XCTAssertTrue([blockProperty isBlock], @"Block property should have isBlock == true");   
+    XCTAssertNil([blockProperty propertyClass], @"Block properties should return nill properties.");
 }
 
 - (void) testIdPropertyIsObject {
-    STAssertTrue([idProperty isObject], @"idProperty should be object.");
+    XCTAssertTrue([idProperty isObject], @"idProperty should be object.");
 }
 
 - (void) testIdProperyIsId {
-    STAssertTrue([idProperty isId], @"idProperty should have isId == true.");
+    XCTAssertTrue([idProperty isId], @"idProperty should have isId == true.");
 }
 
 #pragma mark - Tests for canAcceptValue:
 
 - (void) testIntCanAcceptNSNumber {
     NSNumber *num = [NSNumber numberWithInt:8];
-    STAssertTrue([intProp canAcceptValue:num], @"int properties should be able to accept NSNumber.");
+    XCTAssertTrue([intProp canAcceptValue:num], @"int properties should be able to accept NSNumber.");
 }
 
 - (void) testBoolCanAcceptNSNumber {
     NSNumber *num = [NSNumber numberWithInt:1];
-    STAssertTrue([boolProperty canAcceptValue:num], @"BOOL properties should be able to accept NSNumber.");
+    XCTAssertTrue([boolProperty canAcceptValue:num], @"BOOL properties should be able to accept NSNumber.");
 }
 
 - (void) testBoolCanAcceptNSNumberWithBool {
     NSNumber *num = [NSNumber numberWithBool:YES];
-    STAssertTrue([boolProperty canAcceptValue:num], @"BOOL properties should be able to accept NSNumber numberWithBool:.");
+    XCTAssertTrue([boolProperty canAcceptValue:num], @"BOOL properties should be able to accept NSNumber numberWithBool:.");
 }
 
 - (void) testModelCanAcceptSubmodel {
-    STAssertTrue([modelProp canAcceptValue:[[TestModelSubclass alloc] init] ], @"TestModel properties should be able to accept TestModelSubclass.");
+    XCTAssertTrue([modelProp canAcceptValue:[[TestModelSubclass alloc] init] ], @"TestModel properties should be able to accept TestModelSubclass.");
 }
 
 - (void) testStringCanAcceptString {
-    STAssertTrue([stringProp canAcceptValue:[[NSString alloc] init] ], @"NSString properties should be able to accept NSString.");    
+    XCTAssertTrue([stringProp canAcceptValue:[[NSString alloc] init] ], @"NSString properties should be able to accept NSString.");    
 }
 
 - (void) testStringCannotAcceptNumber {
-    STAssertFalse([stringProp canAcceptValue:[NSNumber numberWithInt:8] ], @"NSString properties should not be able to accept NSNumber.");    
+    XCTAssertFalse([stringProp canAcceptValue:[NSNumber numberWithInt:8] ], @"NSString properties should not be able to accept NSNumber.");    
 }
 
 - (void) testIntCannotAcceptString {
-    STAssertFalse([intProp canAcceptValue:[[NSString alloc] init] ], @"int properties should not be able to accept NSString.");    
+    XCTAssertFalse([intProp canAcceptValue:[[NSString alloc] init] ], @"int properties should not be able to accept NSString.");    
 }
 
 - (void) testIdCanAcceptModel {
-    STAssertTrue([idProperty canAcceptValue:[[TestModel alloc] init] ], @"id properties should be able to accept TestModels.");
+    XCTAssertTrue([idProperty canAcceptValue:[[TestModel alloc] init] ], @"id properties should be able to accept TestModels.");
 }
 
 - (void) testModelCanAcceptId {
     id value = [[TestModel alloc] init];
-    STAssertTrue([modelProp canAcceptValue:value], @"model properties should be able to accept TestModel-valued ids.");
+    XCTAssertTrue([modelProp canAcceptValue:value], @"model properties should be able to accept TestModel-valued ids.");
 }
 
 @end

--- a/JAGPropertyConverterTests/Models/NumberTestModel.h
+++ b/JAGPropertyConverterTests/Models/NumberTestModel.h
@@ -1,0 +1,22 @@
+//
+//  NumberTestModel.h
+//  JAGPropertyConverter
+//
+//  Created by Yen-Chia Lin on 29.01.15.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NumberTestModel : NSObject
+
+@property (nonatomic, assign) BOOL boolProperty;
+@property (nonatomic, assign) int intProperty;
+@property (nonatomic, assign) float floatProperty;
+@property (nonatomic, assign) double doubleProperty;
+@property (nonatomic, assign) long long longLongProperty;
+@property (nonatomic, strong) NSString *stringProperty;
+@property (nonatomic, strong) NSNumber *numberProperty;
+@property (nonatomic, strong) NSNumber *boolNumberProperty;
+
+@end

--- a/JAGPropertyConverterTests/Models/NumberTestModel.m
+++ b/JAGPropertyConverterTests/Models/NumberTestModel.m
@@ -1,0 +1,13 @@
+//
+//  NumberTestModel.m
+//  JAGPropertyConverter
+//
+//  Created by Yen-Chia Lin on 29.01.15.
+//
+//
+
+#import "NumberTestModel.h"
+
+@implementation NumberTestModel
+
+@end

--- a/JAGPropertyConverterTests/Models/TestModel.h
+++ b/JAGPropertyConverterTests/Models/TestModel.h
@@ -25,10 +25,16 @@
 // THE SOFTWARE.
 
 #import <MapKit/MapKit.h>
+#import "JAGPropertyMapping.h"
+
+typedef NS_ENUM(NSInteger, TestModelEnum) {
+    TestModelEnumTypeA,
+    TestModelEnumTypeB
+};
 
 @class JAGPropertyConverter;
 
-@interface TestModel : NSObject 
+@interface TestModel : NSObject <JAGPropertyMapping>
 
 @property (copy)            NSString        *testModelID;
 @property (assign)          int             intProperty;
@@ -46,6 +52,13 @@
 @property (unsafe_unretained)            TestModel       *weakProperty;
 @property (copy)            void(^blockProperty)(id);
 @property (strong)          id              idProperty;
+@property (copy)            NSString        *differentNameProperty;
+@property (nonatomic, assign) TestModelEnum enumProperty;
+@property (nonatomic, assign) TestModelEnum customMappedProperty;
+@property (nonatomic, assign) TestModelEnum snakeCaseEnumProperty;
+@property (nonatomic, copy) NSString *ignoreProperty;
+@property (nonatomic, copy) NSString *customMappedIgnoreProperty;
+@property (nonatomic, copy) NSString *snakeCaseIgnoreProperty;
 
 + (TestModel*) testModel;
 

--- a/JAGPropertyConverterTests/Models/TestModel.m
+++ b/JAGPropertyConverterTests/Models/TestModel.m
@@ -52,7 +52,7 @@
 
 + (JAGPropertyConverter *) testConverter {
     JAGPropertyConverter *converter = [JAGPropertyConverter converterWithOutputType:kJAGPropertyListOutput];
-    converter.identifyDict = ^ Class (NSDictionary *dict) {
+    converter.identifyDict = ^ Class (NSString *propertyName, NSDictionary *dict) {
         if ([dict valueForKey:@"testModelID"])
             return [TestModel class];
         return nil;
@@ -95,6 +95,8 @@
     self.stringProperty = @"Hello Kitty!";
     self.modelProperty = [TestModel testModel];
     self.modelProperty.testModelID = @"KOPES56";
+    self.modelProperty.modelProperty = [TestModel testModel];
+    self.modelProperty.modelProperty.testModelID = @"KPATH101";
     self.arrayProperty = [NSArray arrayWithObjects:@"red", @"green", @"blue", nil];
     self.setProperty = [NSSet setWithObjects:@"alpha", @"beta", @"gamma", nil];
     self.dictionaryProperty = [NSDictionary dictionaryWithObjectsAndKeys: 
@@ -109,6 +111,7 @@
     self.cfProperty = center;
     self.boolProperty = YES;
     self.urlProperty = [NSURL URLWithString:@"http://www.gooogle.com"];
+    self.differentNameProperty = @"Some New Property this is";
 }
 
 + (TestModel*) testModel {
@@ -139,6 +142,39 @@
     _active = active;
 }
 
+#pragma mark - JAGPropertyMapping
+
+- (NSDictionary *)customPropertyMappingConvertingFromJSON {
+    return @{@"someProperty" : @"differentNameProperty",
+             @"enumProperty2" : @"customMappedProperty",
+             @"ignoreProperty2" : @"customMappedIgnoreProperty",
+             @"keypathProperty1" : @"modelProperty.testModelID",
+             @"keypathProperty2" : @"modelProperty.modelProperty.testModelID"};
+}
+
+- (NSDictionary *)customPropertyMappingConvertingToJSON {
+    return @{@"differentNameProperty" : @"someProperty",
+             @"customMappedProperty" : @"enumProperty2",
+             @"customMappedIgnoreProperty" : @"ignoreProperty2",
+             @"modelProperty.testModelID" : @"keypathProperty1",
+             @"modelProperty.modelProperty.testModelID" : @"keypathProperty2"};
+}
+
+- (NSArray *)enumPropertiesToConvertFromJSON {
+    return @[@"enumProperty", @"enumProperty2", @"snake_case_enum_property"];
+}
+
+- (NSArray *)enumPropertiesToConvertToJSON {
+    return @[@"enumProperty", @"customMappedProperty", @"snakeCaseEnumProperty"];
+}
+
+- (NSArray *)ignorePropertiesFromJSON {
+    return @[@"ignoreProperty", @"ignoreProperty2", @"snake_case_ignore_property"];
+}
+
+- (NSArray *)ignorePropertiesToJSON {
+    return @[@"ignoreProperty", @"customMappedIgnoreProperty", @"snakeCaseIgnoreProperty"];
+}
 
 @end
 

--- a/JAGPropertyConverterTests/NullValuesTest.m
+++ b/JAGPropertyConverterTests/NullValuesTest.m
@@ -1,0 +1,109 @@
+//
+//  NullValuesTest.m
+//  JAGPropertyConverter
+//
+//  Created by Yen-Chia Lin on 29.01.15.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+
+#import "JAGPropertyConverter.h"
+#import "NumberTestModel.h"
+
+@interface NullValuesTest : SenTestCase {
+    NumberTestModel *model;
+    JAGPropertyConverter *converter;
+}
+
+@end
+
+@implementation NullValuesTest
+
+- (void)setUp {
+    [super setUp];
+    model = [[NumberTestModel alloc] init];
+    converter = [[JAGPropertyConverter alloc] init];
+    converter.classesToConvert = [NSSet setWithObject:[NumberTestModel class]];
+    
+    // we want NSNull values
+    converter.shouldIgnoreNullValues = NO;
+    
+    NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+    formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en"];
+    converter.numberFormatter = formatter;
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testNullBool {
+    model.boolProperty = YES;
+    STAssertTrue(model.boolProperty, @"boolProperty should be set correctly.");
+    
+    NSDictionary *dict = @{ @"boolProperty" :[NSNull null] };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    STAssertFalse(model.boolProperty, @"boolProperty should be set correctly.");
+}
+
+- (void)testNullInt {
+    model.intProperty = 1337;
+    STAssertEquals(1337, model.intProperty, @"intProperty should be set correctly.");
+    
+    NSDictionary *dict = @{ @"intProperty" : [NSNull null] };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    STAssertEquals(0, model.intProperty, @"intProperty should be set correctly.");
+}
+
+- (void) testNullFloat {
+    float myFloat = 6.8f;
+    model.floatProperty = myFloat;
+    STAssertEqualsWithAccuracy(myFloat, model.floatProperty, 0.01, @"floatProperty %f should be %f.", model.floatProperty, myFloat);
+    
+    NSDictionary *dict = @{ @"floatProperty" : [NSNull null] };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    STAssertEqualsWithAccuracy(0.0f, model.floatProperty, 0.01, @"floatProperty %f should be %f.", model.floatProperty, 0.0f);
+}
+
+- (void) testNullDouble {
+    double myDouble = 6.1234567890123;
+    model.doubleProperty = myDouble;
+    STAssertEqualsWithAccuracy(myDouble, model.doubleProperty, 0.01, @"doubleProperty %f should be %f.", model.doubleProperty, myDouble);
+    
+    NSDictionary *dict = @{ @"doubleProperty" : [NSNull null] };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    STAssertEqualsWithAccuracy(0.0, model.doubleProperty, 0.01, @"doubleProperty %f should be %f.", model.doubleProperty, 0.0);
+}
+
+- (void) testLongLong {
+    long long myLongLong = 61234567890123;
+    model.longLongProperty = myLongLong;
+    STAssertEquals(myLongLong, model.longLongProperty, @"longLongProperty should be set correctly.");
+    
+    NSDictionary *dict = @{ @"longLongProperty" : [NSNull null] };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    STAssertEquals(0ll, model.longLongProperty, @"longLongProperty should be set correctly.");
+}
+
+- (void) testNullNSNumber {
+    NSNumber *myNum = [NSNumber numberWithLong:300];
+    model.numberProperty = myNum;
+    STAssertTrue([myNum isEqualToNumber: model.numberProperty], @"numberProperty %@ should be equal to %@.", model.numberProperty, myNum);
+    
+    NSDictionary *dict = @{ @"numberProperty" : [NSNull null] };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    STAssertNil(model.numberProperty, @"numberProperty should be nil!");
+}
+
+- (void) testNullString {
+    model.stringProperty = @"Everything is awesome!";
+    STAssertEqualObjects(@"Everything is awesome!", model.stringProperty, @"");
+
+    NSDictionary *dict = @{ @"stringProperty" : [NSNull null] };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    STAssertNil(model.stringProperty, @"should be nil");
+}
+
+@end

--- a/JAGPropertyConverterTests/NullValuesTest.m
+++ b/JAGPropertyConverterTests/NullValuesTest.m
@@ -6,12 +6,12 @@
 //
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
 #import "JAGPropertyConverter.h"
 #import "NumberTestModel.h"
 
-@interface NullValuesTest : SenTestCase {
+@interface NullValuesTest : XCTestCase {
     NumberTestModel *model;
     JAGPropertyConverter *converter;
 }
@@ -41,69 +41,69 @@
 
 - (void)testNullBool {
     model.boolProperty = YES;
-    STAssertTrue(model.boolProperty, @"boolProperty should be set correctly.");
+    XCTAssertTrue(model.boolProperty, @"boolProperty should be set correctly.");
     
     NSDictionary *dict = @{ @"boolProperty" :[NSNull null] };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertFalse(model.boolProperty, @"boolProperty should be set correctly.");
+    XCTAssertFalse(model.boolProperty, @"boolProperty should be set correctly.");
 }
 
 - (void)testNullInt {
     model.intProperty = 1337;
-    STAssertEquals(1337, model.intProperty, @"intProperty should be set correctly.");
+    XCTAssertEqual(1337, model.intProperty, @"intProperty should be set correctly.");
     
     NSDictionary *dict = @{ @"intProperty" : [NSNull null] };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertEquals(0, model.intProperty, @"intProperty should be set correctly.");
+    XCTAssertEqual(0, model.intProperty, @"intProperty should be set correctly.");
 }
 
 - (void) testNullFloat {
     float myFloat = 6.8f;
     model.floatProperty = myFloat;
-    STAssertEqualsWithAccuracy(myFloat, model.floatProperty, 0.01, @"floatProperty %f should be %f.", model.floatProperty, myFloat);
+    XCTAssertEqualWithAccuracy(myFloat, model.floatProperty, 0.01, @"floatProperty %f should be %f.", model.floatProperty, myFloat);
     
     NSDictionary *dict = @{ @"floatProperty" : [NSNull null] };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertEqualsWithAccuracy(0.0f, model.floatProperty, 0.01, @"floatProperty %f should be %f.", model.floatProperty, 0.0f);
+    XCTAssertEqualWithAccuracy(0.0f, model.floatProperty, 0.01, @"floatProperty %f should be %f.", model.floatProperty, 0.0f);
 }
 
 - (void) testNullDouble {
     double myDouble = 6.1234567890123;
     model.doubleProperty = myDouble;
-    STAssertEqualsWithAccuracy(myDouble, model.doubleProperty, 0.01, @"doubleProperty %f should be %f.", model.doubleProperty, myDouble);
+    XCTAssertEqualWithAccuracy(myDouble, model.doubleProperty, 0.01, @"doubleProperty %f should be %f.", model.doubleProperty, myDouble);
     
     NSDictionary *dict = @{ @"doubleProperty" : [NSNull null] };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertEqualsWithAccuracy(0.0, model.doubleProperty, 0.01, @"doubleProperty %f should be %f.", model.doubleProperty, 0.0);
+    XCTAssertEqualWithAccuracy(0.0, model.doubleProperty, 0.01, @"doubleProperty %f should be %f.", model.doubleProperty, 0.0);
 }
 
 - (void) testLongLong {
     long long myLongLong = 61234567890123;
     model.longLongProperty = myLongLong;
-    STAssertEquals(myLongLong, model.longLongProperty, @"longLongProperty should be set correctly.");
+    XCTAssertEqual(myLongLong, model.longLongProperty, @"longLongProperty should be set correctly.");
     
     NSDictionary *dict = @{ @"longLongProperty" : [NSNull null] };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertEquals(0ll, model.longLongProperty, @"longLongProperty should be set correctly.");
+    XCTAssertEqual(0ll, model.longLongProperty, @"longLongProperty should be set correctly.");
 }
 
 - (void) testNullNSNumber {
     NSNumber *myNum = [NSNumber numberWithLong:300];
     model.numberProperty = myNum;
-    STAssertTrue([myNum isEqualToNumber: model.numberProperty], @"numberProperty %@ should be equal to %@.", model.numberProperty, myNum);
+    XCTAssertTrue([myNum isEqualToNumber: model.numberProperty], @"numberProperty %@ should be equal to %@.", model.numberProperty, myNum);
     
     NSDictionary *dict = @{ @"numberProperty" : [NSNull null] };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertNil(model.numberProperty, @"numberProperty should be nil!");
+    XCTAssertNil(model.numberProperty, @"numberProperty should be nil!");
 }
 
 - (void) testNullString {
     model.stringProperty = @"Everything is awesome!";
-    STAssertEqualObjects(@"Everything is awesome!", model.stringProperty, @"");
+    XCTAssertEqualObjects(@"Everything is awesome!", model.stringProperty, @"");
 
     NSDictionary *dict = @{ @"stringProperty" : [NSNull null] };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertNil(model.stringProperty, @"should be nil");
+    XCTAssertNil(model.stringProperty, @"should be nil");
 }
 
 @end

--- a/JAGPropertyConverterTests/NumberFormatterTest.h
+++ b/JAGPropertyConverterTests/NumberFormatterTest.h
@@ -6,8 +6,8 @@
 //
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 
-@interface NumberFormatterTest : SenTestCase
+@interface NumberFormatterTest : XCTestCase
 
 @end

--- a/JAGPropertyConverterTests/NumberFormatterTest.h
+++ b/JAGPropertyConverterTests/NumberFormatterTest.h
@@ -8,16 +8,6 @@
 
 #import <SenTestingKit/SenTestingKit.h>
 
-@interface NumberTestModel : NSObject
-
-@property (nonatomic, assign) int intProperty;
-@property (nonatomic, assign) float floatProperty;
-@property (nonatomic, strong) NSNumber *numberProperty;
-@property (nonatomic, strong) NSString *stringProperty;
-
-@end
-
-
 @interface NumberFormatterTest : SenTestCase
 
 @end

--- a/JAGPropertyConverterTests/NumberFormatterTest.m
+++ b/JAGPropertyConverterTests/NumberFormatterTest.m
@@ -8,54 +8,85 @@
 
 #import "NumberFormatterTest.h"
 #import "JAGPropertyConverter.h"
+#import "NumberTestModel.h"
 
-@implementation NumberTestModel
-
-@synthesize intProperty, floatProperty, numberProperty, stringProperty;
+@interface NumberFormatterTest () {
+    NumberTestModel *model;
+    JAGPropertyConverter *converter;
+}
 
 @end
 
-
 @implementation NumberFormatterTest
-
-NumberTestModel *model;
-JAGPropertyConverter *converter;
-
 
 - (void) setUp
 {
     model = [[NumberTestModel alloc] init];
     converter = [[JAGPropertyConverter alloc] init];
-    converter.numberFormatter = [[NSNumberFormatter alloc] init];
     converter.classesToConvert = [NSSet setWithObject:[NumberTestModel class]];
+    
+    NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+    formatter.locale = [NSLocale localeWithLocaleIdentifier:@"en"];
+    converter.numberFormatter = formatter;
+}
+
+- (void) testNSStringToBool
+{
+    NSDictionary *dict = @{ @"boolProperty" : @"true" };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    STAssertTrue(model.boolProperty, @"boolProperty should be set correctly.");
 }
 
 - (void) testNSStringToInt
 {
-    NSDictionary *dict = [NSDictionary dictionaryWithObject:@"7" forKey:@"intProperty"];
+    NSDictionary *dict = @{ @"intProperty" : @"7" };
     [converter setPropertiesOf:model fromDictionary:dict];
     STAssertEquals(7, model.intProperty, @"intProperty should be set correctly.");
 }
 
 - (void) testNSStringToFloat
 {
-    NSDictionary *dict = [NSDictionary dictionaryWithObject:@"6.8" forKey:@"floatProperty"];
+    NSDictionary *dict = @{ @"floatProperty" : @"6.8" };
     [converter setPropertiesOf:model fromDictionary:dict];
     float myFloat = 6.8;
     STAssertEqualsWithAccuracy(myFloat, model.floatProperty, 0.01, @"floatProperty %f should be %f.", model.floatProperty, myFloat);
 }
 
+- (void) testNSStringToDouble
+{
+    NSDictionary *dict = @{ @"doubleProperty" : @"6.1234567890123" };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    double myDouble = 6.1234567890123;
+    STAssertEqualsWithAccuracy(myDouble, model.doubleProperty, 0.01, @"doubleProperty %f should be %f.", model.doubleProperty, myDouble);
+}
+
+- (void) testNSStringToLongLong
+{
+    NSDictionary *dict = @{ @"longLongProperty" : @"61234567890123" };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    long long myLongLong = 61234567890123;
+    STAssertEquals(myLongLong, model.longLongProperty, @"longLongProperty should be set correctly.");
+}
+
 - (void) testNSStringToNSNumberLong
 {
-    NSDictionary *dict = [NSDictionary dictionaryWithObject:@"300" forKey:@"numberProperty"];
+    NSDictionary *dict = @{ @"numberProperty" : @"300" };
     [converter setPropertiesOf:model fromDictionary:dict];
     NSNumber *myNum = [NSNumber numberWithLong:300];
     STAssertTrue([myNum isEqualToNumber: model.numberProperty], @"numberProperty %@ should be equal to %@.", model.numberProperty, myNum);
 }
 
+- (void) testNSStringToNSNumberBool
+{
+    NSDictionary *dict = @{ @"boolNumberProperty" : @"true" };
+    [converter setPropertiesOf:model fromDictionary:dict];
+    NSNumber *myNum = [NSNumber numberWithBool:YES];
+    STAssertTrue([myNum isEqualToNumber: model.boolNumberProperty], @"numberProperty %@ should be equal to %@.", model.boolNumberProperty, myNum);
+}
+
 - (void) testNSStringToNSNumberFloat
 {
-    NSDictionary *dict = [NSDictionary dictionaryWithObject:@"3.3" forKey:@"numberProperty"];
+    NSDictionary *dict = @{ @"numberProperty" : @"3.3" };
     [converter setPropertiesOf:model fromDictionary:dict];
     NSNumber *myNum = [NSNumber numberWithFloat:3.3];
     STAssertEqualsWithAccuracy([myNum floatValue], [model.numberProperty floatValue],  0.01, @"numberProperty %@ should be equal to %@.", model.numberProperty, myNum);
@@ -63,10 +94,9 @@ JAGPropertyConverter *converter;
 
 - (void) testNSStringToNSString
 {
-    NSDictionary *dict = [NSDictionary dictionaryWithObject:@"4" forKey:@"stringProperty"];
+    NSDictionary *dict = @{ @"stringProperty" : @"4" };
     [converter setPropertiesOf:model fromDictionary:dict];
     STAssertEqualObjects(@"4", model.stringProperty, @"stringProperty should not be converted.");
 }
-
 
 @end

--- a/JAGPropertyConverterTests/NumberFormatterTest.m
+++ b/JAGPropertyConverterTests/NumberFormatterTest.m
@@ -34,14 +34,14 @@
 {
     NSDictionary *dict = @{ @"boolProperty" : @"true" };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertTrue(model.boolProperty, @"boolProperty should be set correctly.");
+    XCTAssertTrue(model.boolProperty, @"boolProperty should be set correctly.");
 }
 
 - (void) testNSStringToInt
 {
     NSDictionary *dict = @{ @"intProperty" : @"7" };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertEquals(7, model.intProperty, @"intProperty should be set correctly.");
+    XCTAssertEqual(7, model.intProperty, @"intProperty should be set correctly.");
 }
 
 - (void) testNSStringToFloat
@@ -49,7 +49,7 @@
     NSDictionary *dict = @{ @"floatProperty" : @"6.8" };
     [converter setPropertiesOf:model fromDictionary:dict];
     float myFloat = 6.8;
-    STAssertEqualsWithAccuracy(myFloat, model.floatProperty, 0.01, @"floatProperty %f should be %f.", model.floatProperty, myFloat);
+    XCTAssertEqualWithAccuracy(myFloat, model.floatProperty, 0.01, @"floatProperty %f should be %f.", model.floatProperty, myFloat);
 }
 
 - (void) testNSStringToDouble
@@ -57,7 +57,7 @@
     NSDictionary *dict = @{ @"doubleProperty" : @"6.1234567890123" };
     [converter setPropertiesOf:model fromDictionary:dict];
     double myDouble = 6.1234567890123;
-    STAssertEqualsWithAccuracy(myDouble, model.doubleProperty, 0.01, @"doubleProperty %f should be %f.", model.doubleProperty, myDouble);
+    XCTAssertEqualWithAccuracy(myDouble, model.doubleProperty, 0.01, @"doubleProperty %f should be %f.", model.doubleProperty, myDouble);
 }
 
 - (void) testNSStringToLongLong
@@ -65,7 +65,7 @@
     NSDictionary *dict = @{ @"longLongProperty" : @"61234567890123" };
     [converter setPropertiesOf:model fromDictionary:dict];
     long long myLongLong = 61234567890123;
-    STAssertEquals(myLongLong, model.longLongProperty, @"longLongProperty should be set correctly.");
+    XCTAssertEqual(myLongLong, model.longLongProperty, @"longLongProperty should be set correctly.");
 }
 
 - (void) testNSStringToNSNumberLong
@@ -73,7 +73,7 @@
     NSDictionary *dict = @{ @"numberProperty" : @"300" };
     [converter setPropertiesOf:model fromDictionary:dict];
     NSNumber *myNum = [NSNumber numberWithLong:300];
-    STAssertTrue([myNum isEqualToNumber: model.numberProperty], @"numberProperty %@ should be equal to %@.", model.numberProperty, myNum);
+    XCTAssertTrue([myNum isEqualToNumber: model.numberProperty], @"numberProperty %@ should be equal to %@.", model.numberProperty, myNum);
 }
 
 - (void) testNSStringToNSNumberBool
@@ -81,7 +81,7 @@
     NSDictionary *dict = @{ @"boolNumberProperty" : @"true" };
     [converter setPropertiesOf:model fromDictionary:dict];
     NSNumber *myNum = [NSNumber numberWithBool:YES];
-    STAssertTrue([myNum isEqualToNumber: model.boolNumberProperty], @"numberProperty %@ should be equal to %@.", model.boolNumberProperty, myNum);
+    XCTAssertTrue([myNum isEqualToNumber: model.boolNumberProperty], @"numberProperty %@ should be equal to %@.", model.boolNumberProperty, myNum);
 }
 
 - (void) testNSStringToNSNumberFloat
@@ -89,14 +89,14 @@
     NSDictionary *dict = @{ @"numberProperty" : @"3.3" };
     [converter setPropertiesOf:model fromDictionary:dict];
     NSNumber *myNum = [NSNumber numberWithFloat:3.3];
-    STAssertEqualsWithAccuracy([myNum floatValue], [model.numberProperty floatValue],  0.01, @"numberProperty %@ should be equal to %@.", model.numberProperty, myNum);
+    XCTAssertEqualWithAccuracy([myNum floatValue], [model.numberProperty floatValue],  0.01, @"numberProperty %@ should be equal to %@.", model.numberProperty, myNum);
 }
 
 - (void) testNSStringToNSString
 {
     NSDictionary *dict = @{ @"stringProperty" : @"4" };
     [converter setPropertiesOf:model fromDictionary:dict];
-    STAssertEqualObjects(@"4", model.stringProperty, @"stringProperty should not be converted.");
+    XCTAssertEqualObjects(@"4", model.stringProperty, @"stringProperty should not be converted.");
 }
 
 @end

--- a/JAGPropertyConverterTests/PropertyModelTests.h
+++ b/JAGPropertyConverterTests/PropertyModelTests.h
@@ -23,10 +23,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import <UIKit/UIKit.h>
 
-@interface PropertyModelTests : SenTestCase
+@interface PropertyModelTests : XCTestCase
 
 
 @end

--- a/JAGPropertyConverterTests/PropertyModelTests.m
+++ b/JAGPropertyConverterTests/PropertyModelTests.m
@@ -54,20 +54,20 @@
     model.modelProperty = otherModel;
     
     NSDictionary *props = [model propertiesAsDictionary];
-    STAssertEquals([[props valueForKey:@"intProperty"] intValue], intProp, 
+    XCTAssertEqual([[props valueForKey:@"intProperty"] intValue], intProp, 
                    @"props should have interProperty %d, but is %d", intProp,
                    [[props valueForKey:@"intProperty"] intValue]);
-    STAssertEquals([props valueForKey:@"stringProperty"], stringProp, 
+    XCTAssertEqual([props valueForKey:@"stringProperty"], stringProp, 
                    @"props should have stringProperty %@, but is %@", stringProp,
                    [props valueForKey:@"stringProperty"]);
     
     id foundOtherModel = [props valueForKey:@"modelProperty"];
-    STAssertTrue([foundOtherModel isKindOfClass: [NSDictionary class]], 
+    XCTAssertTrue([foundOtherModel isKindOfClass: [NSDictionary class]], 
                    @"modelProperty should be NSDictionary after parsing, but is %@.", [foundOtherModel class]);
-    STAssertEquals([[foundOtherModel valueForKey:@"intProperty"] intValue], otherIntProp, 
+    XCTAssertEqual([[foundOtherModel valueForKey:@"intProperty"] intValue], otherIntProp, 
                    @"foundOtherModel should have interProperty %d, but is %d", intProp,
                    [[foundOtherModel valueForKey:@"intProperty"] intValue]);
-    STAssertEquals([foundOtherModel valueForKey:@"stringProperty"], otherStringProp, 
+    XCTAssertEqual([foundOtherModel valueForKey:@"stringProperty"], otherStringProp, 
                    @"props should have stringProperty %@, but is %@", otherStringProp,
                    [foundOtherModel valueForKey:@"stringProperty"]);
     
@@ -94,20 +94,20 @@
     
     [model setPropertiesFromDictionary:props];
     
-    STAssertEquals(model.intProperty, intProp, 
+    XCTAssertEqual(model.intProperty, intProp, 
                    @"model should have interProperty %d, but is %d", intProp,
                    model.intProperty);
-    STAssertEquals(model.stringProperty, stringProp, 
+    XCTAssertEqual(model.stringProperty, stringProp, 
                    @"model should have stringProperty %@, but is %@", stringProp,
                    model.stringProperty);
     
     TestModel *foundOtherModel = model.modelProperty;
-    STAssertTrue([foundOtherModel isMemberOfClass: [TestModel class]], 
+    XCTAssertTrue([foundOtherModel isMemberOfClass: [TestModel class]], 
                  @"modelProperty should return a TestModel, but returned %@.", [foundOtherModel class]);
-    STAssertEquals(foundOtherModel.intProperty, otherIntProp, 
+    XCTAssertEqual(foundOtherModel.intProperty, otherIntProp, 
                    @"other model should have intProperty %d, but is %d", otherIntProp,
                    foundOtherModel.intProperty);
-    STAssertEquals(foundOtherModel.stringProperty, otherStringProp, 
+    XCTAssertEqual(foundOtherModel.stringProperty, otherStringProp, 
                    @"other model should have stringProperty %@, but is %@", otherStringProp,
                    foundOtherModel.stringProperty);
     

--- a/JAGPropertyConverterTests/SnakeCaseTest.m
+++ b/JAGPropertyConverterTests/SnakeCaseTest.m
@@ -1,0 +1,33 @@
+//
+//  SnakeCaseTest.m
+//  JAGPropertyConverter
+//
+//  Created by Yen-Chia Lin on 27.11.14.
+//
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import "NSString+JAGSnakeCaseSupport.h"
+
+@interface SnakeCaseTest : SenTestCase
+
+@end
+
+@implementation SnakeCaseTest
+
+- (void)testConvertToCamelCase {
+    STAssertEqualObjects([@"hello" asCamelCaseFromUnderscore], @"hello", @"no change");
+    STAssertEqualObjects([@"Hello" asCamelCaseFromUnderscore], @"Hello", @"no change");
+    STAssertEqualObjects([@"hello there" asCamelCaseFromUnderscore], @"hello there", @"no change");
+    STAssertEqualObjects([@"hello_there" asCamelCaseFromUnderscore], @"helloThere", @"convert");
+    STAssertEqualObjects([@"stay awhile and listen" asCamelCaseFromUnderscore], @"stay awhile and listen", @"no change");
+    STAssertEqualObjects([@"stay_awhile_and_listen" asCamelCaseFromUnderscore], @"stayAwhileAndListen", @"convert");
+    STAssertEqualObjects([@"created_at" asCamelCaseFromUnderscore], @"createdAt", @"convert");
+    STAssertEqualObjects([@"created_at_1234" asCamelCaseFromUnderscore], @"createdAt1234", @"convert");
+}
+
+- (void)testConvertToSnakeCase {
+    STAssertEqualObjects([@"createdAt1234" asUnderscoreFromCamelCase], @"created_at1234", @"convert");
+}
+
+@end

--- a/JAGPropertyConverterTests/SnakeCaseTest.m
+++ b/JAGPropertyConverterTests/SnakeCaseTest.m
@@ -6,28 +6,28 @@
 //
 //
 
-#import <SenTestingKit/SenTestingKit.h>
+#import <XCTest/XCTest.h>
 #import "NSString+JAGSnakeCaseSupport.h"
 
-@interface SnakeCaseTest : SenTestCase
+@interface SnakeCaseTest : XCTestCase
 
 @end
 
 @implementation SnakeCaseTest
 
 - (void)testConvertToCamelCase {
-    STAssertEqualObjects([@"hello" asCamelCaseFromUnderscore], @"hello", @"no change");
-    STAssertEqualObjects([@"Hello" asCamelCaseFromUnderscore], @"Hello", @"no change");
-    STAssertEqualObjects([@"hello there" asCamelCaseFromUnderscore], @"hello there", @"no change");
-    STAssertEqualObjects([@"hello_there" asCamelCaseFromUnderscore], @"helloThere", @"convert");
-    STAssertEqualObjects([@"stay awhile and listen" asCamelCaseFromUnderscore], @"stay awhile and listen", @"no change");
-    STAssertEqualObjects([@"stay_awhile_and_listen" asCamelCaseFromUnderscore], @"stayAwhileAndListen", @"convert");
-    STAssertEqualObjects([@"created_at" asCamelCaseFromUnderscore], @"createdAt", @"convert");
-    STAssertEqualObjects([@"created_at_1234" asCamelCaseFromUnderscore], @"createdAt1234", @"convert");
+    XCTAssertEqualObjects([@"hello" asCamelCaseFromUnderscore], @"hello", @"no change");
+    XCTAssertEqualObjects([@"Hello" asCamelCaseFromUnderscore], @"Hello", @"no change");
+    XCTAssertEqualObjects([@"hello there" asCamelCaseFromUnderscore], @"hello there", @"no change");
+    XCTAssertEqualObjects([@"hello_there" asCamelCaseFromUnderscore], @"helloThere", @"convert");
+    XCTAssertEqualObjects([@"stay awhile and listen" asCamelCaseFromUnderscore], @"stay awhile and listen", @"no change");
+    XCTAssertEqualObjects([@"stay_awhile_and_listen" asCamelCaseFromUnderscore], @"stayAwhileAndListen", @"convert");
+    XCTAssertEqualObjects([@"created_at" asCamelCaseFromUnderscore], @"createdAt", @"convert");
+    XCTAssertEqualObjects([@"created_at_1234" asCamelCaseFromUnderscore], @"createdAt1234", @"convert");
 }
 
 - (void)testConvertToSnakeCase {
-    STAssertEqualObjects([@"createdAt1234" asUnderscoreFromCamelCase], @"created_at1234", @"convert");
+    XCTAssertEqualObjects([@"createdAt1234" asUnderscoreFromCamelCase], @"created_at1234", @"convert");
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ NSURL properties are not technically valid for JSON or ProperyLists, so JAGPrope
 
 NSDate properties are not valid for JSON, and different use cases will call for different serialization methods.  We allow for this by the convertToDate and convertFromDate block properties.  They are called when converting to/from NSDate properties with JSON output type.
 
+### NSData
+
+JAGPropertyConverter converts NSData into for example Base 64 string and vice-versa as needed.
+
 ### NSObject properties
 
 NSObject itself has some properties.  JAGPropertyFinder ignores these.  If there is need in the future, JAGPropertyFinder could take a setting determining whether it ignores or finds those properties.
@@ -64,6 +68,21 @@ NSObject itself has some properties.  JAGPropertyFinder ignores these.  If there
 ### NSSet
 
 JAGPropertyConverter converts arrays to sets and vice-versa, as needed.
+
+### Enums
+
+JAGPropertyConverter also supports conversion of NS_ENUMs to strings and vice-versa.
+
+## New Features Since 0.2.0
+
+* Custom property name mapping: `JAGPropertyMapping`
+* Support converting `NSData` (eg. into Base64 strings): `convertToData` and `convertFromData`
+* Support converting enums: `convertToEnum` and `convertFromEnum`
+* Support for auto converting to/from **snake_case**: `enableSnakeCaseSupport`
+* Support for ingoring `nil`/`null` vales: `shouldIngoreNullValues`
+* Support to ignore `weak` properties for serialization: `shouldConvertWeakProperties`
+* Extracted and restructured some methods so JAGPropertyConverter can be subclassed: `JAGPropertyConverter+Subclass.h`
+* Enhanced `identifyDict`: it will now pass in the dictionary name (breaking change!)
 
 ## Example Usage
 


### PR DESCRIPTION
## New Features Since 0.2.0

* Custom property name mapping: `JAGPropertyMapping`
* Support converting `NSData` (eg. into Base64 strings): `convertToData` and `convertFromData`
* Support converting enums: `convertToEnum` and `convertFromEnum`
* Support for auto converting to/from **snake_case**: `enableSnakeCaseSupport`
* Support for ingoring `nil`/`null` vales: `shouldIngoreNullValues`
* Support to ignore `weak` properties for serialization: `shouldConvertWeakProperties`
* Extracted and restructured some methods so JAGPropertyConverter can be subclassed: `JAGPropertyConverter+Subclass.h`
* Enhanced `identifyDict`: it will now pass in the dictionary name (breaking change!)
* Added `isBoolean` to JAGProperty